### PR TITLE
Add pre-commit GitHub Action to run go vet on PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,19 @@
+---
+name: Pre-commit
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Run Go vet
+        run: go vet ./...


### PR DESCRIPTION
This PR introduces a new GitHub Action workflow named Pre-commit, which runs on all pull requests.

The workflow performs the following:
- Checks out the repository
- Sets up Go 1.24
- Runs `go vet ./...` to catch potential issues in the codebase