### PR TITLE
Fixes for image and code-style workflows

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -46,7 +46,7 @@ jobs:
           set -euo pipefail
 
           TOOL="${{ matrix.tool }}"
-          OPTIONS="${{ matrix.options:- }}"
+          OPTIONS="${{ matrix.options || '' }}"
 
           TMP_LIST="$(mktemp)"
           find . \

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -58,6 +58,7 @@ jobs:
             echo "No .go files found; nothing to do."
             exit 0
           fi
+          
           if ! xargs -0 -a "$TMP_LIST" -- ${TOOL} ${OPTIONS} -w; then
             echo "${TOOL} failed on the following files:"
             tr '\0' '\n' < "$TMP_LIST"

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -44,6 +44,8 @@ jobs:
         shell: bash
         run: >
           TMP_LIST="$(mktemp)"
+          TOOL="${{ matrix.tool }}"
+          OPTIONS="${{ matrix.options || '' }}"
           
           set -euo pipefail
 
@@ -52,9 +54,6 @@ jobs:
             -name '*.deepcopy.go' -prune -o \
             -type f -name '*.go' -print0 > "$TMP_LIST"
           
-          TOOL="${{ matrix.tool }}"
-          OPTIONS="${{ matrix.options || '' }}"
-
           if [ ! -s "$TMP_LIST" ]; then
             echo "No .go files found; nothing to do."
             exit 0

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -43,16 +43,17 @@ jobs:
       - name: Run ${{ matrix.tool }} ${{ matrix.options }}
         shell: bash
         run: >
+          TMP_LIST="$(mktemp)"
+          
           set -euo pipefail
 
-          TOOL="${{ matrix.tool }}"
-          OPTIONS="${{ matrix.options || '' }}"
-
-          TMP_LIST="$(mktemp)"
           find . \
             -path ./docs -prune -o \
             -name '*.deepcopy.go' -prune -o \
             -type f -name '*.go' -print0 > "$TMP_LIST"
+          
+          TOOL="${{ matrix.tool }}"
+          OPTIONS="${{ matrix.options || '' }}"
 
           if [ ! -s "$TMP_LIST" ]; then
             echo "No .go files found; nothing to do."

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -7,7 +7,7 @@ on:
     tags: [ 'v*' ]
   merge_group:
     types: [ checks_requested ]
-  
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -36,32 +36,34 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref_name }}
           tags: |
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}   
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Print Docker metadata for debugging (simple)
+        run: |
+          echo "Generated Tags: ${{ steps.meta.outputs.tags }}"
+          echo "Generated Labels: ${{ steps.meta.outputs.labels }}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-   
       - name: Build and Push Image
         id: build-image
         uses: Wandalen/wretry.action@v3.8.0
         with:
           action: docker/build-push-action@v5
-          with: |
-            context: .
-            file: ./Dockerfile
-            platforms: linux/amd64,linux/arm64
-            push: true
-            provenance: true
-            tags: ${{ steps.meta.outputs.tags }}
-            labels: ${{ steps.meta.outputs.labels }}
-          attempt_limit: 3          
-          attempt_delay: 15000      
-          time_out: 3600000         
-
-     
+          attempt_limit: 3
+          attempt_delay: 15000
+          time_out: 3600000
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,8 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/
 
 .specstory
 .cursorindexingignore


### PR DESCRIPTION
Fix for errors:

code-style.yaml
The `:-` syntax for default values doesn't work with GitHub Actions matrix variables. If `matrix.options` is undefined, this will result in `OPTIONS=""` rather than using a default value.

images.yaml

An error message "can not read a block mapping entry; a multiline key may not be an implicit key (15:1)
12 | org.opencontainers.image.title" 

was caused by the formatting/structure of the "Build and Push Image" job

Fix:
1. no need for "|" and 
2. no nested "with".