### PR TITLE
broker: local dev + controller in Kube helper

### DIFF
--- a/config/test-servers/server3-deployment.yaml
+++ b/config/test-servers/server3-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       - name: mcp-test-server3
         image: ghcr.io/kagenti/mcp-gateway/test-server3:latest
         imagePullPolicy: IfNotPresent
-        command: ["fastmcp", "run", "server.py", "--transport", "http"]
+        command: ["fastmcp", "run", "server.py", "--transport", "http", "--host", "0.0.0.0"]
         ports:
         - containerPort: 8000
           name: http


### PR DESCRIPTION
add a new `make dev-broker-local` target to:

- start the broker locally
- use the configfile from the controller, and rewrite the config with local port forward host/posts for the 3 test servers deployed in kube. 
- Reverts a change to use the HTTPRoute hostname for broker->upstream MCP servers, now uses service host

```bash
make dev-broker-local
Setting up local broker with port-forwarded upstreams...
Starting port-forwards for MCP servers...
Config rewritten for local ports:
  server1: localhost:9091
  server2: localhost:9092
  server3: localhost:9093

Starting broker locally...
./bin/mcp-broker-router --mcp-gateway-config=/tmp/mcp-broker-config-local.yaml --mcp-broker-address=0.0.0.0:8080 --mcp-router-address=0.0.0.0:50051
2025/08/29 15:58:47 INFO Registering server mcpHost=http://localhost:9091/mcp prefix=s1_
2025/08/29 15:58:47 INFO Discovered tools mcpHost=http://localhost:9091/mcp "num tools"=4
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9091/mcp "federated name"=s1_-greet
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9091/mcp "federated name"=s1_-headers
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9091/mcp "federated name"=s1_-slow
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9091/mcp "federated name"=s1_-time
2025/08/29 15:58:47 INFO Registering server mcpHost=http://localhost:9092/mcp prefix=s2_
2025/08/29 15:58:47 INFO Discovered tools mcpHost=http://localhost:9092/mcp "num tools"=5
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9092/mcp "federated name"=s2_-auth1234
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9092/mcp "federated name"=s2_-headers
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9092/mcp "federated name"=s2_-hello_world
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9092/mcp "federated name"=s2_-slow
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9092/mcp "federated name"=s2_-time
2025/08/29 15:58:47 INFO Registering server mcpHost=http://localhost:9093/mcp prefix=s3_
2025/08/29 15:58:47 INFO Discovered tools mcpHost=http://localhost:9093/mcp "num tools"=6
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9093/mcp "federated name"=s3_-time
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9093/mcp "federated name"=s3_-add
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9093/mcp "federated name"=s3_-dozen
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9093/mcp "federated name"=s3_-pi
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9093/mcp "federated name"=s3_-get_weather
2025/08/29 15:58:47 INFO Federating tool mcpHost=http://localhost:9093/mcp "federated name"=s3_-slow
time=2025-08-29T15:58:47.209+01:00 level=INFO msg="[http] starting MCP Broker" listening=0.0.0.0:8080
time=2025-08-29T15:58:47.209+01:00 level=INFO msg="[grpc] starting MCP Router" listening=0.0.0.0:50051
```