### PR TITLE
Code coverage targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,3 +252,15 @@ logs: ## Tail Istio gateway logs
 	@$(MAKE) -s -f build/debug.mk debug-logs-gateway-impl
 
 -include build/*.mk
+
+.PHONY: testwithcoverage
+testwithcoverage:
+	go test ./... -coverprofile=coverage.out
+
+.PHONY: coverage
+coverage: testwithcoverage
+	@echo "test coverage: $(shell go tool cover -func coverage.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}')"
+
+.PHONY: htmlcov
+htmlcov: coverage
+	go tool cover -html=coverage.out


### PR DESCRIPTION
Code coverage targets.

Current unit test coverage is 17.5%.

To test, `make coverage` to see the code coverage.  `make htmlcov` to start a web browser which shows the lines covered and not covered by the unit tests.