### PR TITLE
don't teardown existing kind clusters on setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,6 @@ local-env-setup: ## Setup complete local demo environment with Kind, Istio, MCP 
 	@echo "Starting MCP Gateway Environment Setup"
 	@echo "========================================="
 	$(MAKE) tools
-	$(MAKE) kind-delete-cluster
 	$(MAKE) kind-create-cluster
 	$(MAKE) build-and-load-image
 	$(MAKE) gateway-api-install

--- a/build/kind.mk
+++ b/build/kind.mk
@@ -4,7 +4,12 @@ KIND_CLUSTER_NAME ?= mcp-gateway
 
 .PHONY: kind-create-cluster
 kind-create-cluster: kind # Create the "mcp-gateway" kind cluster.
-	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config config/kind/cluster.yaml
+	@if $(KIND) get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
+		echo "Kind cluster '$(KIND_CLUSTER_NAME)' already exists, skipping creation"; \
+	else \
+		echo "Creating Kind cluster '$(KIND_CLUSTER_NAME)'..."; \
+		$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config config/kind/cluster.yaml; \
+	fi
 
 .PHONY: kind-delete-cluster
 kind-delete-cluster: kind # Delete the "mcp-gateway" kind cluster.


### PR DESCRIPTION
Don't teardown existing `kind` clusters on setup, skip if cluster found. Users can call `make local-env-teardown` to explicitly teardown.