### PR TITLE
fix issue where servers are not unregistered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build-and-load-image:
 	@echo "Building and loading image into Kind cluster..."
 	docker build ${BUILDFLAGS} -t ghcr.io/kagenti/mcp-gateway:latest .
 	kind load docker-image ghcr.io/kagenti/mcp-gateway:latest --name mcp-gateway
-	kubectl rollout restart deployment/mcp-broker-router -n mcp-system
+	kubectl rollout restart deployment/mcp-broker-router -n mcp-system 2>/dev/null || true
 
 # Deploy example MCPServer
 deploy-example: install-crd ## Deploy example MCPServer resource

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ build-and-load-image:
 	@echo "Building and loading image into Kind cluster..."
 	docker build ${BUILDFLAGS} -t ghcr.io/kagenti/mcp-gateway:latest .
 	kind load docker-image ghcr.io/kagenti/mcp-gateway:latest --name mcp-gateway
+	kubectl rollout restart deployment/mcp-broker-router -n mcp-system
 
 # Deploy example MCPServer
 deploy-example: install-crd ## Deploy example MCPServer resource

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -152,7 +152,7 @@ func (m *mcpBrokerImpl) IsRegistered(mcpHost string) bool {
 
 func (m *mcpBrokerImpl) OnConfigChange(ctx context.Context, conf *config.MCPServersConfig) {
 	m.logger.Debug("Broker OnConfigChange called")
-	// unregister decomissioned servers
+	// unregister decommissioned servers
 	for upstreamHost := range m.mcpServers {
 		if !slices.ContainsFunc(conf.Servers, func(s *config.MCPServer) bool {
 			return upstreamHost == upstreamMCPHost(s.URL)

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-var _ config.ConfigObserver = &mcpBrokerImpl{}
+var _ config.Observer = &mcpBrokerImpl{}
 
 // downstreamSessionID is for session IDs the gateway uses with its own clients
 type downstreamSessionID string
@@ -79,7 +79,7 @@ type MCPBroker interface {
 	// CreateSession creates a new MCP session for the given authority/host
 	CreateSession(ctx context.Context, authority string) (string, error)
 
-	config.ConfigObserver
+	config.Observer
 }
 
 // mcpBrokerImpl implements MCPBroker

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,13 +6,15 @@ import "context"
 // MCPServersConfig holds server configuration
 type MCPServersConfig struct {
 	Servers   []*MCPServer
-	observers []ConfigObserver
+	observers []Observer
 }
 
-func (config *MCPServersConfig) RegisterObserver(obs ConfigObserver) {
+// RegisterObserver registers an observer to be notified of changes to the config
+func (config *MCPServersConfig) RegisterObserver(obs Observer) {
 	config.observers = append(config.observers, obs)
 }
 
+// Notify notifies registered observers of config changes
 func (config *MCPServersConfig) Notify(ctx context.Context) {
 	for _, observer := range config.observers {
 		observer.OnConfigChange(ctx, config)
@@ -28,6 +30,7 @@ type MCPServer struct {
 	Hostname   string
 }
 
-type ConfigObserver interface {
+// Observer provides an interface to implement inorder to register as an Observer of config changes
+type Observer interface {
 	OnConfigChange(ctx context.Context, config *MCPServersConfig)
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,9 +1,22 @@
 // Package config provides configuration types
 package config
 
+import "context"
+
 // MCPServersConfig holds server configuration
 type MCPServersConfig struct {
-	Servers []*MCPServer
+	Servers   []*MCPServer
+	observers []ConfigObserver
+}
+
+func (config *MCPServersConfig) RegisterObserver(obs ConfigObserver) {
+	config.observers = append(config.observers, obs)
+}
+
+func (config *MCPServersConfig) Notify(ctx context.Context) {
+	for _, observer := range config.observers {
+		observer.OnConfigChange(ctx, config)
+	}
 }
 
 // MCPServer represents a server
@@ -13,4 +26,8 @@ type MCPServer struct {
 	ToolPrefix string
 	Enabled    bool
 	Hostname   string
+}
+
+type ConfigObserver interface {
+	OnConfigChange(ctx context.Context, config *MCPServersConfig)
 }

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kagenti/mcp-gateway/internal/config"
 )
 
-var _ config.ConfigObserver = &ExtProcServer{}
+var _ config.Observer = &ExtProcServer{}
 
 // ExtProcServer struct boolean for streaming & Store headers for later use in body processing
 type ExtProcServer struct {

--- a/internal/mcp-router/server.go
+++ b/internal/mcp-router/server.go
@@ -26,7 +26,8 @@ type ExtProcServer struct {
 	requestHeaders *extProcV3.HttpHeaders
 }
 
-func (s *ExtProcServer) OnConfigChange(ctx context.Context, newConfig *config.MCPServersConfig) {
+// OnConfigChange is used to register the router for config changes
+func (s *ExtProcServer) OnConfigChange(_ context.Context, newConfig *config.MCPServersConfig) {
 	s.RoutingConfig = newConfig
 }
 


### PR DESCRIPTION
fixes #100 
This can be verified by adding an MCPServer resource and then removing one of the target refs. If using `make local-env-setup` one of these is created for you 

```
spec:
    targetRefs:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
      name: mcp-server1-route
      toolPrefix: s1_
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
      name: mcp-server2-route
      toolPrefix: s2_
```