### PR TITLE
Remove individual tool prefix from targetRefs to reduce complexity

### DIFF
--- a/config/crd/mcpserver.yaml
+++ b/config/crd/mcpserver.yaml
@@ -77,12 +77,9 @@ spec:
                     namespace:
                       type: string
                       description: Namespace of the HTTPRoute (optional, defaults to same namespace)
-                    toolPrefix:
-                      type: string
-                      description: Tool prefix for this specific server (overrides spec-level toolPrefix)
               toolPrefix:
                 type: string
-                description: ToolPrefix is the default prefix to add to all federated tools from referenced servers. This helps avoid naming conflicts when aggregating tools from multiple sources. Can be overridden per targetRef.
+                description: ToolPrefix is the prefix to add to all federated tools from referenced servers. This helps avoid naming conflicts when aggregating tools from multiple sources.
           status:
             type: object
             description: Status represents the observed state of the MCPServer resource

--- a/config/samples/mcpserver-multiserver.yaml
+++ b/config/samples/mcpserver-multiserver.yaml
@@ -4,38 +4,33 @@ metadata:
   name: ai-assistant-tools
   namespace: mcp-system
 spec:
+  # Tool prefix applied to all servers in this MCPServer
+  toolPrefix: ai_
+  
   # Multiple HTTPRoute references for different MCP servers
   targetRefs:
-  # Weather service with explicit prefix
+  # Weather service
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: weather-route
     namespace: mcp-system
-    toolPrefix: weather_
   
   # Calendar service  
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: calendar-route
-    toolPrefix: cal_
   
   # Search service - same namespace
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: search-route
-    toolPrefix: search_
   
-  # Knowledge base service - uses default prefix
+  # Knowledge base service
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: knowledge-route
-    # No toolPrefix - will use spec-level default
   
-  # Documentation service - uses default prefix
+  # Documentation service
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: docs-route
-    # No toolPrefix - will use spec-level default
-  
-  # Default prefix for targetRefs without explicit toolPrefix
-  toolPrefix: ai_

--- a/config/samples/mcpserver-test-servers.yaml
+++ b/config/samples/mcpserver-test-servers.yaml
@@ -4,26 +4,23 @@ metadata:
   name: test-servers
   namespace: mcp-test
 spec:
+  # Tool prefix applied to all servers in this MCPServer
+  toolPrefix: test_
+  
   # Reference all three test MCP servers via their HTTPRoutes
   targetRefs:
   # Server 1 - Go SDK based (hi, time, slow, headers tools)
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: mcp-server1-route
-    toolPrefix: s1_
   
   # Server 2 - Go SDK based (similar tools, different implementation)
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: mcp-server2-route
-    toolPrefix: s2_
   
   # Server 3 - Python FastMCP based (time, add, dozen, pi, get_weather, slow)
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: mcp-server3-route
-    toolPrefix: s3_
-  
-  # Default tool prefix if not specified per-server
-  toolPrefix: test_
 

--- a/pkg/apis/mcp/v1alpha1/types.go
+++ b/pkg/apis/mcp/v1alpha1/types.go
@@ -28,11 +28,10 @@ type MCPServerSpec struct {
 	// the broker to federate tools from those MCP servers.
 	TargetRefs []TargetReference `json:"targetRefs"`
 
-	// ToolPrefix is the default prefix to add to all federated tools from referenced servers.
+	// ToolPrefix is the prefix to add to all federated tools from referenced servers.
 	// This helps avoid naming conflicts when aggregating tools from multiple sources.
 	// For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_'
 	// ensure they can coexist as 'server1_search' and 'server2_search'.
-	// Can be overridden per targetRef.
 	// +optional
 	ToolPrefix string `json:"toolPrefix,omitempty"`
 }
@@ -56,10 +55,6 @@ type TargetReference struct {
 	// Namespace of the target resource (optional, defaults to same namespace)
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
-
-	// ToolPrefix to use for this specific server (overrides spec-level toolPrefix)
-	// +optional
-	ToolPrefix string `json:"toolPrefix,omitempty"`
 }
 
 // MCPServerStatus represents the observed state of the MCPServer resource.

--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -255,10 +255,7 @@ func (r *MCPServerReconciler) discoverServersFromHTTPRoutes(
 			nameAndEndpoint = serviceDNSName
 		}
 
-		toolPrefix := targetRef.ToolPrefix
-		if toolPrefix == "" {
-			toolPrefix = mcpServer.Spec.ToolPrefix
-		}
+		toolPrefix := mcpServer.Spec.ToolPrefix
 
 		// Extract hostname from HTTPRoute
 		if len(httpRoute.Spec.Hostnames) != 1 {


### PR DESCRIPTION
After a chat with @maleck13 

- Removed individual tool prefix for now form individual servers in `targetRefs[]`
- Prefix can be set for all servers in an `MCPServer`

If we think we want this again, we can add back later.