### PR TITLE
test fixes - RoutingConfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,6 @@ golangci-lint:
 lint: fmt vet golangci-lint
 
 test-unit:
-	echo "blah blah blah test"
 	go test ./...
 
 .PHONY: tools

--- a/internal/mcp-router/request_test.go
+++ b/internal/mcp-router/request_test.go
@@ -2,6 +2,8 @@ package mcprouter
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -161,8 +163,9 @@ func TestGetServerInfo(t *testing.T) {
 }
 
 func TestHandleRequestBody(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	server := &ExtProcServer{
-		MCPConfig: &config.MCPServersConfig{
+		RoutingConfig: &config.MCPServersConfig{
 			Servers: []*config.MCPServer{
 				{
 					Name:       "dummy",
@@ -173,7 +176,7 @@ func TestHandleRequestBody(t *testing.T) {
 				},
 			},
 		},
-		Broker: broker.NewBroker(),
+		Broker: broker.NewBroker(logger),
 	}
 
 	data := map[string]any{

--- a/internal/mcp-router/server_test.go
+++ b/internal/mcp-router/server_test.go
@@ -2,9 +2,8 @@
 package mcprouter
 
 import (
-
-	// "github.com/kagenti/mcp-gateway/internal/config"
-
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/kagenti/mcp-gateway/internal/broker"
@@ -12,8 +11,9 @@ import (
 )
 
 func TestSetupSessionCache(_ *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	server := &ExtProcServer{
-		MCPConfig: &config.MCPServersConfig{
+		RoutingConfig: &config.MCPServersConfig{
 			Servers: []*config.MCPServer{
 				{
 					Name:       "dummy",
@@ -24,7 +24,7 @@ func TestSetupSessionCache(_ *testing.T) {
 				},
 			},
 		},
-		Broker: broker.NewBroker(),
+		Broker: broker.NewBroker(logger),
 	}
 
 	// We can't test the internals of this, because it returns nothing on error...

--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,7 +150,7 @@ func (r *MCPServerReconciler) regenerateAggregatedConfig(
 
 	log.Info("Successfully regenerated aggregated configuration",
 		"serverCount", len(brokerConfig.Servers))
-	return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	return reconcile.Result{}, nil
 }
 
 func (r *MCPServerReconciler) writeAggregatedConfig(


### PR DESCRIPTION
Small PR, tests broken on main

Some chicken vs egg between 

https://github.com/kagenti/mcp-gateway/pull/98
https://github.com/kagenti/mcp-gateway/pull/109

To solve - we should probably enable a [merge-queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue). That way, we can run tests prior to merge with unrebased PRs that way, and catch this sort of thing.

@huang195 perhaps you have perms to enable for this repo? I would enable but not an org/repo owner