### PR TITLE
Option to require security on test server test2 for all interactions

### DIFF
--- a/tests/servers/server2/README.md
+++ b/tests/servers/server2/README.md
@@ -105,3 +105,12 @@ curl -v ${MCP} -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/
 }
 '
 ```
+
+### Security options
+
+To require a bearer token, define `EXPECTED_AUTH`
+
+- EXPECTED_AUTH="Bearer 1234" MCP_TRANSPORT=http PORT=9091 go run main.go
+- docker run --publish 9091:9090 --EXPECTED_AUTH="Bearer 1234" --env MCP_TRANSPORT=http --env PORT=9090 mcp-test2
+
+Then, before Connecting in the MCP Inspector console, expand _Authorization_ and set the Bearer Token value to `1234`.  (Note that the MCP inspector prepends this with "Bearer ", so the value set in the MCP Inspector UI doesn't match exactly with what the test MCP server receives).

--- a/tests/servers/server2/README.md
+++ b/tests/servers/server2/README.md
@@ -110,7 +110,7 @@ curl -v ${MCP} -H "mcp-session-id: ${SESSION_ID}" -H "Content-Type: application/
 
 To require a bearer token, define `EXPECTED_AUTH`
 
-- EXPECTED_AUTH="Bearer 1234" MCP_TRANSPORT=http PORT=9091 go run main.go
-- docker run --publish 9091:9090 --EXPECTED_AUTH="Bearer 1234" --env MCP_TRANSPORT=http --env PORT=9090 mcp-test2
+- `EXPECTED_AUTH="Bearer 1234" MCP_TRANSPORT=http PORT=9091 go run main.go`
+- `docker run --publish 9091:9090 --EXPECTED_AUTH="Bearer 1234" --env MCP_TRANSPORT=http --env PORT=9090 mcp-test2`
 
 Then, before Connecting in the MCP Inspector console, expand _Authorization_ and set the Bearer Token value to `1234`.  (Note that the MCP inspector prepends this with "Bearer ", so the value set in the MCP Inspector UI doesn't match exactly with what the test MCP server receives).


### PR DESCRIPTION
For #69 comment https://github.com/kagenti/mcp-gateway/issues/69#issuecomment-3257644837

This modifies test server 2 with environment options so that it may be configured to require a bearer token for all interactions, including init and tools/list.

This does NOT modify the mcp-test-server2 Deployment we set up in the dev environment, but it makes that possible.

To test this PR, start mcp-test-server2 in one of two ways:

- `EXPECTED_AUTH="Bearer 1234" MCP_TRANSPORT=http PORT=9091 go run main.go`
- Docker build _mcp-test2_ then `docker run --publish 9091:9090 --EXPECTED_AUTH="Bearer 1234" --env MCP_TRANSPORT=http --env PORT=9090 mcp-test2`

Start the MCP Inspector in the usual way, then, before Connecting in the MCP Inspector console, expand _Authorization_ and set the Bearer Token value to `1234`.  (Note that the MCP inspector prepends this with "Bearer ", so the value set in the MCP Inspector UI doesn't match exactly with what the test MCP server receives).