### PR TITLE
Expose test servers

### DIFF
--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -25,8 +25,29 @@ spec:
           selector:
             matchLabels:
               kubernetes.io/metadata.name: keycloak
+    - name: mcp-server1-route
+      hostname: 'server1.127-0-0-1.sslip.io'
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: mcp-server2-route
+      hostname: 'server2.127-0-0-1.sslip.io'
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: mcp-server3-route
+      hostname: 'server3.127-0-0-1.sslip.io'
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
     - name: mcps
-      hostname: '*.mcp.local' # set to test.com on purpose to illustrate it doesn't matter what is in here but something has to be in here
+      hostname: '*.mcp.local'
       port: 8080
       protocol: HTTP
       allowedRoutes:

--- a/config/test-servers/server1-httproute.yaml
+++ b/config/test-servers/server1-httproute.yaml
@@ -9,7 +9,8 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server1.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by envoy
+    - 'server1.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
+    - 'server1.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:

--- a/config/test-servers/server2-httproute.yaml
+++ b/config/test-servers/server2-httproute.yaml
@@ -9,7 +9,8 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server2.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by envoy
+    - 'server2.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
+    - 'server2.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:

--- a/config/test-servers/server3-httproute.yaml
+++ b/config/test-servers/server3-httproute.yaml
@@ -9,7 +9,8 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server3.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by envoy
+    - 'server3.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
+    - 'server3.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:


### PR DESCRIPTION
Resolves #121

This PR exposes the three test servers that we federate as individual servers.  This behavior is useful for comparing the behavior of MCP when connected directly vs going through the gateway.

To use this, follow the instructions to set up the cluster and run the Inspector, but instead of connecting to `mcp.127-0-0-1.sslip.io:8888/mcp` connect to

- http://server1.127-0-0-1.sslip.io:8888/mcp
- http://server2.127-0-0-1.sslip.io:8888/mcp
- http://server3.127-0-0-1.sslip.io:8888/mcp
