### PR TITLE
Use different httproute for external vs internal

### DIFF
--- a/config/istio/gateway/gateway.yaml
+++ b/config/istio/gateway/gateway.yaml
@@ -25,21 +25,21 @@ spec:
           selector:
             matchLabels:
               kubernetes.io/metadata.name: keycloak
-    - name: mcp-server1-route
+    - name: mcp-server1-route-ext
       hostname: 'server1.127-0-0-1.sslip.io'
       port: 8080
       protocol: HTTP
       allowedRoutes:
         namespaces:
           from: All
-    - name: mcp-server2-route
+    - name: mcp-server2-route-ext
       hostname: 'server2.127-0-0-1.sslip.io'
       port: 8080
       protocol: HTTP
       allowedRoutes:
         namespaces:
           from: All
-    - name: mcp-server3-route
+    - name: mcp-server3-route-ext
       hostname: 'server3.127-0-0-1.sslip.io'
       port: 8080
       protocol: HTTP

--- a/config/test-servers/kustomization.yaml
+++ b/config/test-servers/kustomization.yaml
@@ -8,10 +8,13 @@ resources:
   - server1-deployment.yaml
   - server1-service.yaml
   - server1-httproute.yaml
+  - server1-httproute-ext.yaml
   - server2-deployment.yaml
   - server2-service.yaml
   - server2-httproute.yaml
+  - server2-httproute-ext.yaml
   - server3-deployment.yaml
   - server3-service.yaml
   - server3-httproute.yaml
+  - server3-httproute-ext.yaml
 

--- a/config/test-servers/server1-httproute-ext.yaml
+++ b/config/test-servers/server1-httproute-ext.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: mcp-server3-route
+  name: mcp-server1-route-ext
   labels:
     mcp-server: 'true'
 spec:
@@ -9,12 +9,12 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server3.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
+    - 'server1.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: mcp-test-server3
+        - name: mcp-test-server1
           port: 9090

--- a/config/test-servers/server1-httproute.yaml
+++ b/config/test-servers/server1-httproute.yaml
@@ -10,7 +10,6 @@ spec:
       namespace: gateway-system
   hostnames:
     - 'server1.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
-    - 'server1.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:

--- a/config/test-servers/server2-httproute-ext.yaml
+++ b/config/test-servers/server2-httproute-ext.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: mcp-server3-route
+  name: mcp-server2-route-ext
   labels:
     mcp-server: 'true'
 spec:
@@ -9,12 +9,12 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server3.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
+    - 'server2.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: mcp-test-server3
+        - name: mcp-test-server2
           port: 9090

--- a/config/test-servers/server2-httproute.yaml
+++ b/config/test-servers/server2-httproute.yaml
@@ -10,7 +10,6 @@ spec:
       namespace: gateway-system
   hostnames:
     - 'server2.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
-    - 'server2.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:

--- a/config/test-servers/server3-httproute-ext.yaml
+++ b/config/test-servers/server3-httproute-ext.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: mcp-server3-route
+  name: mcp-server3-route-ext
   labels:
     mcp-server: 'true'
 spec:
@@ -9,7 +9,7 @@ spec:
     - name: mcp-gateway
       namespace: gateway-system
   hostnames:
-    - 'server3.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by Envoy
+    - 'server3.127-0-0-1.sslip.io'
   rules:
     - matches:
         - path:

--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -283,12 +283,14 @@ func (r *MCPServerReconciler) discoverServersFromHTTPRoutes(
 
 	// Extract hostname from HTTPRoute
 	if len(httpRoute.Spec.Hostnames) != 1 {
-		return nil, fmt.Errorf(
+		err := fmt.Errorf(
 			"HTTPRoute %s/%s must have exactly one hostname for MCP backend routing, found %d",
 			namespace,
 			targetRef.Name,
-			len(httpRoute.Spec.Hostnames),
-		)
+			len(httpRoute.Spec.Hostnames))
+		log := log.FromContext(ctx)
+		log.Error(err, "Ignoring route")
+		return nil, err
 	}
 	hostname := string(httpRoute.Spec.Hostnames[0])
 


### PR DESCRIPTION
Fixes the problem of MCP servers being ignored when we create the local dev environment cluster.