### PR TITLE
Add support for a get_headers tool

### DIFF
--- a/tests/servers/server3/Dockerfile
+++ b/tests/servers/server3/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 
-RUN pip install fastmcp
+RUN pip install fastmcp>=2.12.2
 COPY *.py /app
 
 # CMD ["fastmcp run server.py --host 0.0.0.0 --port 9090 --transport http"]

--- a/tests/servers/server3/server.py
+++ b/tests/servers/server3/server.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import time as pytime # If we don't rename this, it confuses fastmcp
 
 from fastmcp import FastMCP, Context
+from fastmcp.server.dependencies import get_http_headers
 
 mcp = FastMCP("FastMCP test server")
 
@@ -52,6 +53,13 @@ async def slow(seconds: int, ctx: Context) -> str:
         pytime.sleep(1)
 
     return ""
+
+@mcp.tool
+def get_headers() -> dict[str, str]:
+    """Gets the HTTP headers."""
+    # Note that get_http_headers returns init headers
+    # See https://github.com/jlowin/fastmcp/issues/1233
+    return get_http_headers(include_all=True)
 
 if __name__ == "__main__":
     # NOTE THIS NEVER GETS INVOKED.  WE RUN WITH THE FastMCP harness:


### PR DESCRIPTION
This adds support for getting the HTTP headers using the Python test server.

This will be helpful for troubleshooting problems with MCP header reconnection; see https://github.com/kagenti/mcp-gateway/issues/50#issuecomment-3275586702