### PR TITLE
fix some outdated options that weren't updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ spec:
 ## Command Line Flags
 
 ```bash
---mcp-router-address    # gRPC ext_proc address (default: 0.0.0.0:50051)
---mcp-broker-address    # HTTP broker address (default: 0.0.0.0:8080)
---mcp-gateway-config    # Config file path (default: ./config/mcp-system/config.yaml)
---controller            # Enable Kubernetes controller mode
+--mcp-router-address            # gRPC ext_proc address (default: 0.0.0.0:50051)
+--mcp-broker-public-address     # HTTP broker address (default: 0.0.0.0:8080)
+--mcp-gateway-config            # Config file path (default: ./config/mcp-system/config.yaml)
+--controller                    # Enable Kubernetes controller mode
 ```
 
 ### OAuth Configuration

--- a/build/dev.mk
+++ b/build/dev.mk
@@ -95,7 +95,7 @@ dev-broker-local: ## Run broker locally with port-forwarded MCP servers
 	@echo "  server3: localhost:9093"
 	@echo ""
 	@echo "Starting broker locally..."
-	./bin/mcp-broker-router --mcp-gateway-config=/tmp/mcp-broker-config-local.yaml --mcp-broker-address=0.0.0.0:8080 --mcp-router-address=0.0.0.0:50051
+	./bin/mcp-broker-router --mcp-gateway-config=/tmp/mcp-broker-config-local.yaml --mcp-broker-public-address=0.0.0.0:8080 --mcp-router-address=0.0.0.0:50051
 
 # Stop local broker and port-forwards
 .PHONY: dev-broker-stop


### PR DESCRIPTION
Changing `-mcp-broker-address` to `-mcp-broker-public-address` in doc and Makefile as the name of the CLI option was changed.