### PR TITLE
MCPServer creds: secret watching

### DIFF
--- a/cmd/mcp-broker-router/main.go
+++ b/cmd/mcp-broker-router/main.go
@@ -313,8 +313,9 @@ func runController() error {
 	}
 
 	if err = (&controller.MCPReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -23,6 +23,11 @@ spec:
         - name: config-volume
           configMap:
             name: mcp-gateway-config
+        - name: mcp-credentials
+          secret:
+            secretName: mcp-aggregated-credentials
+            defaultMode: 0400
+            optional: true  # broker can still work without credentials
       containers:
         - name: mcp-broker-router
           image: ghcr.io/kagenti/mcp-gateway:latest
@@ -40,13 +45,6 @@ spec:
                 secretKeyRef:
                   name: mcp-config-update-token
                   key: token
-            # retry configuration for failed server discovery (optional)
-            # - name: MCP_GATEWAY_DISCOVERY_RETRY_BASE_DELAY
-            #   value: "5s"  # initial retry delay (default: 5s)
-            # - name: MCP_GATEWAY_DISCOVERY_RETRY_MAX_DELAY
-            #   value: "5m"  # maximum retry delay (default: 5m)
-            # - name: MCP_GATEWAY_DISCOVERY_RETRY_MAX_ATTEMPTS
-            #   value: "10"  # maximum retry attempts (default: 10)
           envFrom:
             - secretRef:
                 name: mcp-aggregated-credentials
@@ -54,6 +52,9 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /config
+            - name: mcp-credentials
+              mountPath: /etc/mcp-credentials
+              readOnly: true
           ports:
             - name: http
               containerPort: 8080

--- a/config/test-servers/api-key-server-secret.yaml
+++ b/config/test-servers/api-key-server-secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: api-key-server-credentials
   namespace: mcp-test
+  labels:
+    mcp.kagenti.com/credential: "true"  # required label for credential secrets
 type: Opaque
 stringData:
   token: "Bearer test-api-key-secret-token"

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"slices"
 	"strconv"
 	"time"
 
 	"github.com/kagenti/mcp-gateway/internal/config"
+	"github.com/kagenti/mcp-gateway/pkg/credentials"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -208,16 +208,24 @@ func (m *mcpBrokerImpl) RegisterServerWithConfig(
 			existingUpstream.Hostname != mcpServer.Hostname ||
 			existingUpstream.CredentialEnvVar != mcpServer.CredentialEnvVar
 
-		if !configChanged {
-			m.logger.Info("MCP server is already registered with same config", "mcpURL", mcpServer.URL)
+		// also check if credential VALUE changed (not just env var name)
+		credentialValueChanged := false
+		if mcpServer.CredentialEnvVar != "" {
+			oldCred := credentials.Get(existingUpstream.CredentialEnvVar)
+			newCred := credentials.Get(mcpServer.CredentialEnvVar)
+			credentialValueChanged = oldCred != newCred
+		}
+
+		if !configChanged && !credentialValueChanged {
+			m.logger.Info("mcp server is already registered with same config", "mcpURL", mcpServer.URL)
 			return nil
 		}
 
-		// config changed, unregister and re-register
-		m.logger.Info("MCP server config changed, re-registering",
+		// config or credentials changed, unregister and re-register
+		m.logger.Info("mcp server config or credentials changed, re-registering",
 			"mcpURL", mcpServer.URL,
-			"oldPrefix", existingUpstream.ToolPrefix,
-			"newPrefix", mcpServer.ToolPrefix)
+			"configChanged", configChanged,
+			"credentialValueChanged", credentialValueChanged)
 
 		if err := m.UnregisterServer(ctx, mcpServer.URL); err != nil {
 			m.logger.Warn("failed to unregister before re-registration", "error", err)
@@ -230,18 +238,17 @@ func (m *mcpBrokerImpl) RegisterServerWithConfig(
 		MCPServer: *mcpServer,
 	}
 
+	// Add to map BEFORE discovering tools so createMCPClient can find it
+	m.mcpServers[upstreamMCPURL(mcpServer.URL)] = upstream
+
 	newTools, err := m.discoverTools(ctx, upstream)
 	if err != nil {
 		slog.Info("Failed to discover tools, will retry with backoff", "mcpURL", mcpServer.URL, "error", err)
-		// register server even if discovery fails, will retry in background
-		m.mcpServers[upstreamMCPURL(mcpServer.URL)] = upstream
 		// start background retry with exponential backoff
 		go m.retryDiscovery(context.Background(), upstream)
 		return nil // don't return error, allow partial registration
 	}
 	slog.Info("Discovered tools", "mcpURL", mcpServer.URL, "num tools", len(newTools))
-
-	m.mcpServers[upstreamMCPURL(mcpServer.URL)] = upstream
 	slog.Info("Server registered", "url", mcpServer.URL, "totalServers", len(m.mcpServers))
 	m.listeningMCPServer.AddTools(toolsToServerTools(mcpServer.URL, newTools)...)
 
@@ -368,9 +375,6 @@ func (m *mcpBrokerImpl) discoverTools(ctx context.Context, upstream *upstreamMCP
 	// Some MCP servers require a bearer token or other Authorization to init and list tools
 	serverAuthHeaderValue := getAuthorizationHeaderForUpstream(upstream)
 	if serverAuthHeaderValue != "" {
-		slog.Info("Adding auth header for discovery",
-			"url", upstream.URL,
-			"credentialEnvVar", upstream.CredentialEnvVar)
 		options = append(options, transport.WithHTTPHeaders(map[string]string{
 			"Authorization": serverAuthHeaderValue,
 		}))
@@ -670,14 +674,26 @@ func (m *mcpBrokerImpl) HandleStatusRequest(w http.ResponseWriter, r *http.Reque
 
 // createMCPClient creates and initializes an MCP client with the appropriate configuration
 func (m *mcpBrokerImpl) createMCPClient(ctx context.Context, mcpURL, name string, clientType ClientType, options ...transport.StreamableHTTPCOption) (*client.Client, *mcp.InitializeResult, error) {
-	// Add auth headers if needed
-	authHeader := getAuthorizationHeaderForUpstream(&upstreamMCP{
-		MCPServer: config.MCPServer{Name: name, URL: mcpURL},
-	})
-	if authHeader != "" {
-		options = append(options, transport.WithHTTPHeaders(map[string]string{
-			"Authorization": authHeader,
-		}))
+	// Look up the actual upstream config to get CredentialEnvVar
+	upstream, found := m.mcpServers[upstreamMCPURL(mcpURL)]
+	if found {
+		// Use the registered upstream with its CredentialEnvVar
+		authHeader := getAuthorizationHeaderForUpstream(upstream)
+		if authHeader != "" {
+			options = append(options, transport.WithHTTPHeaders(map[string]string{
+				"Authorization": authHeader,
+			}))
+		}
+	} else {
+		// fallback for unregistered servers (shouldn't happen normally)
+		authHeader := getAuthorizationHeaderForUpstream(&upstreamMCP{
+			MCPServer: config.MCPServer{Name: name, URL: mcpURL},
+		})
+		if authHeader != "" {
+			options = append(options, transport.WithHTTPHeaders(map[string]string{
+				"Authorization": authHeader,
+			}))
+		}
 	}
 
 	httpClient, err := client.NewStreamableHttpClient(mcpURL, options...)
@@ -731,12 +747,17 @@ func (m *mcpBrokerImpl) createMCPClient(ctx context.Context, mcpURL, name string
 func getAuthorizationHeaderForUpstream(upstream *upstreamMCP) string {
 	// We don't store the authorization in the config.yaml, which comes from a ConfigMap.
 	// Instead it is passed to the Broker pod through env vars (typically from Secrets)
+	var credName string
 	if upstream.CredentialEnvVar != "" {
-		return os.Getenv(upstream.CredentialEnvVar)
+		credName = upstream.CredentialEnvVar
+	} else {
+		// The format is KAGENTAI_{MCP_NAME}_CRED=xxxxxxxx
+		// e.g. KAGENTAI_test_CRED="Bearer 1234"
+		credName = fmt.Sprintf("KAGENTAI_%s_CRED", upstream.Name)
 	}
-	// The format is KAGENTAI_{MCP_NAME}_CRED=xxxxxxxx
-	// e.g. KAGENTAI_test_CRED="Bearer 1234"
-	return os.Getenv(fmt.Sprintf("KAGENTAI_%s_CRED", upstream.Name))
+
+	authValue := credentials.Get(credName)
+	return authValue
 }
 
 // prefixedName returns the name the gateway will advertise the tool as

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"strconv"
 	"time"

--- a/internal/broker/config_handler.go
+++ b/internal/broker/config_handler.go
@@ -73,6 +73,7 @@ func (h *ConfigUpdateHandler) UpdateConfig(w http.ResponseWriter, r *http.Reques
 	if configData.VirtualServers != nil {
 		h.config.VirtualServers = configData.VirtualServers
 	}
+
 	h.config.Notify(r.Context())
 
 	h.logger.Info("configuration updated via API", "serverCount", len(configData.Servers), "virtualServerCount", len(configData.VirtualServers))

--- a/internal/mcp-router/request.go
+++ b/internal/mcp-router/request.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
-	"os"
 	"strings"
 
 	basepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/kagenti/mcp-gateway/internal/config"
+	"github.com/kagenti/mcp-gateway/pkg/credentials"
 )
 
 const (
@@ -363,7 +363,7 @@ func (s *ExtProcServer) createRoutingResponse(
 
 	// add auth header if needed
 	if serverInfo != nil && serverInfo.CredentialEnvVar != "" {
-		authValue := os.Getenv(serverInfo.CredentialEnvVar)
+		authValue := credentials.Get(serverInfo.CredentialEnvVar)
 		if authValue != "" {
 			slog.Info("Adding Authorization header for routing",
 				"server", serverName,

--- a/pkg/controller/config_pusher.go
+++ b/pkg/controller/config_pusher.go
@@ -60,7 +60,6 @@ func (p *ConfigPusher) PushConfig(ctx context.Context, servers []*config.MCPServ
 	}
 
 	// get endpoints for the config service
-	// using endpoints api (simpler than endpointslice for our needs)
 	endpoints := &corev1.Endpoints{} //nolint:staticcheck
 	err = p.k8sClient.Get(ctx, client.ObjectKey{
 		Namespace: p.namespace,

--- a/pkg/controller/configmap_writer.go
+++ b/pkg/controller/configmap_writer.go
@@ -121,11 +121,12 @@ func convertToInternalFormat(servers []config.ServerConfig) []*internalconfig.MC
 	result := make([]*internalconfig.MCPServer, len(servers))
 	for i, s := range servers {
 		result[i] = &internalconfig.MCPServer{
-			Name:       s.Name,
-			URL:        s.URL,
-			ToolPrefix: s.ToolPrefix,
-			Enabled:    s.Enabled,
-			Hostname:   s.Hostname,
+			Name:             s.Name,
+			URL:              s.URL,
+			ToolPrefix:       s.ToolPrefix,
+			Enabled:          s.Enabled,
+			Hostname:         s.Hostname,
+			CredentialEnvVar: s.CredentialEnvVar,
 		}
 	}
 	return result

--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -999,11 +999,17 @@ func (r *MCPReconciler) aggregateCredentials(ctx context.Context, mcpServers []m
 		secret := &corev1.Secret{}
 		var err error
 		if r.APIReader != nil {
+			log.V(1).Info("Using APIReader to bypass cache for credential secret read",
+				"mcpserver", mcpServer.Name,
+				"secret", mcpServer.Spec.CredentialRef.Name)
 			err = r.APIReader.Get(ctx, types.NamespacedName{
 				Name:      mcpServer.Spec.CredentialRef.Name,
 				Namespace: mcpServer.Namespace,
 			}, secret)
 		} else {
+			log.Info("WARNING: APIReader is nil, using cached client for credential secret read",
+				"mcpserver", mcpServer.Name,
+				"secret", mcpServer.Spec.CredentialRef.Name)
 			err = r.Get(ctx, types.NamespacedName{
 				Name:      mcpServer.Spec.CredentialRef.Name,
 				Namespace: mcpServer.Namespace,

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -1,0 +1,28 @@
+// Package credentials reads from mounted secrets
+package credentials
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// MountPath is the standard mount path for credentials
+	MountPath = "/etc/mcp-credentials"
+)
+
+// Get reads credential from mounted secret file
+func Get(name string) string {
+	credPath := filepath.Join(MountPath, name)
+	data, err := os.ReadFile(credPath) //nolint:gosec // reading kubernetes mounted secrets
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// log non-enoent errors
+			slog.Debug("Failed to read credential file", "path", credPath, "error", err)
+		}
+		return "" // empty if not found
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,0 +1,80 @@
+package credentials
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name           string
+		credName       string
+		fileContent    string
+		expectedResult string
+	}{
+		{
+			name:           "reads from file",
+			credName:       "TEST_FILE_CRED",
+			fileContent:    "file-secret-456\n",
+			expectedResult: "file-secret-456",
+		},
+		{
+			name:           "returns empty when file doesn't exist",
+			credName:       "MISSING_FILE_CRED",
+			fileContent:    "", // no file created
+			expectedResult: "",
+		},
+		{
+			name:           "handles Bearer token format",
+			credName:       "BEARER_TOKEN",
+			fileContent:    "Bearer ghp_abcdef123456",
+			expectedResult: "Bearer ghp_abcdef123456",
+		},
+		{
+			name:           "trims whitespace",
+			credName:       "WHITESPACE_CRED",
+			fileContent:    "  secret-with-spaces  \n",
+			expectedResult: "secret-with-spaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create temp dir to simulate mount path
+			tempDir := t.TempDir()
+
+			// setup file if needed
+			if tt.fileContent != "" {
+				credPath := filepath.Join(tempDir, tt.credName)
+				if err := os.WriteFile(credPath, []byte(tt.fileContent), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// use helper for testing with custom path
+			result := getFromPath(tempDir, tt.credName)
+
+			// verify
+			if result != tt.expectedResult {
+				t.Errorf("Get(%q) = %q, want %q", tt.credName, result, tt.expectedResult)
+			}
+		})
+	}
+}
+
+// test helper with custom mount path
+func getFromPath(mountPath, name string) string {
+	credPath := filepath.Join(mountPath, name)
+	data, err := os.ReadFile(credPath) //nolint:gosec // test helper reading test files
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// log non-enoent errors
+			fmt.Printf("Failed to read credential file %s: %v\n", credPath, err)
+		}
+		return "" // empty if not found
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/tests/e2e/commons.go
+++ b/tests/e2e/commons.go
@@ -23,7 +23,7 @@ import (
 const (
 	TestTimeoutMedium     = time.Second * 30
 	TestTimeoutLong       = time.Minute * 2
-	TestTimeoutConfigSync = time.Minute * 3 // configmap volume mount sync can take up to 2 minutes
+	TestTimeoutConfigSync = time.Minute * 4
 	TestRetryInterval     = time.Second * 2
 
 	TestNamespace   = "mcp-test"

--- a/tests/e2e/happy_path_test.go
+++ b/tests/e2e/happy_path_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -402,7 +403,270 @@ var _ = Describe("MCP Gateway Happy Path", func() {
 
 		By("Test completed successfully")
 	})
+
+	It("should handle credential changes and re-register servers", func() {
+		By("Creating HTTPRoute for api-key-server")
+		httpRouteApiKey := BuildTestHTTPRoute("e2e-apikey-route", TestNamespace,
+			"apikey.mcp.example.com", "mcp-api-key-server", 9090)
+		_ = k8sClient.Delete(ctx, httpRouteApiKey)
+		time.Sleep(2 * time.Second)
+		Expect(k8sClient.Create(ctx, httpRouteApiKey)).To(Succeed())
+		defer CleanupResource(ctx, k8sClient, httpRouteApiKey)
+
+		By("Creating credential secret with valid token")
+		credentialSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "e2e-apikey-credentials",
+				Namespace: TestNamespace,
+				Labels: map[string]string{
+					"mcp.kagenti.com/credential": "true",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			StringData: map[string]string{
+				"token": "Bearer test-api-key-secret-token", // valid token
+			},
+		}
+		_ = k8sClient.Delete(ctx, credentialSecret)
+		time.Sleep(2 * time.Second)
+		Expect(k8sClient.Create(ctx, credentialSecret)).To(Succeed())
+		defer CleanupResource(ctx, k8sClient, credentialSecret)
+
+		// wait for secret to be fully created and readable
+		By("Verifying credential secret is created with data")
+		Eventually(func() bool {
+			secret := &corev1.Secret{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "e2e-apikey-credentials",
+				Namespace: TestNamespace,
+			}, secret); err != nil {
+				return false
+			}
+			// check secret has the token data
+			if secret.Data == nil || len(secret.Data["token"]) == 0 {
+				return false
+			}
+			return string(secret.Data["token"]) == "Bearer test-api-key-secret-token"
+		}, TestTimeoutMedium, TestRetryInterval).Should(BeTrue())
+
+		By("Creating MCPServer with credential reference")
+		mcpServerApiKey := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "e2e-apikey-server",
+				Namespace: TestNamespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				ToolPrefix: "e2ecred_", // unique prefix to avoid conflicts
+				TargetRef: mcpv1alpha1.TargetReference{
+					Group: "gateway.networking.k8s.io",
+					Kind:  "HTTPRoute",
+					Name:  "e2e-apikey-route",
+				},
+				CredentialRef: &mcpv1alpha1.SecretReference{
+					Name: "e2e-apikey-credentials",
+					Key:  "token",
+				},
+			},
+		}
+		_ = k8sClient.Delete(ctx, mcpServerApiKey)
+		time.Sleep(2 * time.Second)
+		Expect(k8sClient.Create(ctx, mcpServerApiKey)).To(Succeed())
+		defer CleanupResource(ctx, k8sClient, mcpServerApiKey)
+
+		// wait for aggregated secret to be created with the credential
+		By("Waiting for aggregated credentials secret to contain the credential")
+		Eventually(func() bool {
+			aggregatedSecret := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "mcp-aggregated-credentials",
+				Namespace: SystemNamespace,
+			}, aggregatedSecret)
+			if err != nil {
+				return false
+			}
+			// check if the expected credential env var exists and has value
+			envVarName := "KAGENTAI_E2E_APIKEY_SERVER_CRED"
+			if val, exists := aggregatedSecret.Data[envVarName]; exists {
+				return string(val) == "Bearer test-api-key-secret-token"
+			}
+			return false
+		}, TestTimeoutMedium, TestRetryInterval).Should(BeTrue(),
+			"Aggregated secret should contain the credential")
+
+		By("Verifying MCPServer becomes ready with valid credentials")
+		// For servers with credentials, we need to wait longer due to volume mount sync
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerApiKey.Name,
+				Namespace: mcpServerApiKey.Namespace,
+			}, mcpServer)
+			if err != nil {
+				return false
+			}
+
+			for _, condition := range mcpServer.Status.Conditions {
+				if condition.Type == "Ready" && condition.Status == metav1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}, TestTimeoutConfigSync, TestRetryInterval).Should(BeTrue(),
+			"MCPServer should become ready with valid credentials")
+
+		By("Setting up port-forward to broker for status check")
+		statusPortForwardCmd := setupPortForward("mcp-broker-router", SystemNamespace, "18083:8080")
+		defer statusPortForwardCmd.Process.Kill()
+
+		// wait for port-forward to be ready
+		Eventually(func() error {
+			client := &http.Client{Timeout: 1 * time.Second}
+			resp, err := client.Get("http://localhost:18083/status")
+			if err != nil {
+				return err
+			}
+			resp.Body.Close()
+			return nil
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		By("Verifying server is registered with valid credentials")
+		// Initial registration may need to wait for volume mount sync
+		// Periodically trigger config reloads to prompt registration once credentials are available
+		Eventually(func() bool {
+			// trigger config reload to prompt re-registration
+			mcpServerPatch := client.MergeFrom(mcpServerApiKey.DeepCopy())
+			if mcpServerApiKey.Annotations == nil {
+				mcpServerApiKey.Annotations = make(map[string]string)
+			}
+			mcpServerApiKey.Annotations["reconcile-initial"] = fmt.Sprintf("%d", time.Now().Unix())
+			_ = k8sClient.Patch(ctx, mcpServerApiKey, mcpServerPatch)
+
+			// wait a moment for config push
+			time.Sleep(2 * time.Second)
+
+			// check if server is registered and reachable
+			// Look for the actual service name: mcp-api-key-server
+			reachable, err := verifyServerInBrokerStatus("http://localhost:18083/status", "mcp-api-key-server", true)
+			return err == nil && reachable
+		}, TestTimeoutConfigSync, 10*time.Second).Should(BeTrue(),
+			"Server should be registered and reachable with valid credentials after volume mount sync")
+
+		By("Updating credential to invalid value")
+		// patch secret with invalid token
+		patch := client.MergeFrom(credentialSecret.DeepCopy())
+		credentialSecret.StringData = map[string]string{
+			"token": "Bearer invalid-token",
+		}
+		Expect(k8sClient.Patch(ctx, credentialSecret, patch)).To(Succeed())
+
+		By("Waiting for volume mount to sync credential change")
+		// Volume mounts can take 60-120s to sync in Kubernetes
+		// We'll wait and periodically trigger config reloads until the broker detects the change
+		Eventually(func() bool {
+			// trigger config reload by annotating mcpserver
+			mcpServerPatch := client.MergeFrom(mcpServerApiKey.DeepCopy())
+			if mcpServerApiKey.Annotations == nil {
+				mcpServerApiKey.Annotations = make(map[string]string)
+			}
+			mcpServerApiKey.Annotations["reconcile"] = fmt.Sprintf("%d", time.Now().Unix())
+			if err := k8sClient.Patch(ctx, mcpServerApiKey, mcpServerPatch); err != nil {
+				return false
+			}
+
+			// wait a moment for the config push to process
+			time.Sleep(2 * time.Second)
+
+			// check if server became unreachable (indicating credential change was detected)
+			reachable, err := verifyServerInBrokerStatus("http://localhost:18083/status", "mcp-api-key-server", false)
+			if err != nil {
+				// server might be completely removed from status
+				return true
+			}
+			return !reachable
+		}, TestTimeoutConfigSync, 10*time.Second).Should(BeTrue(),
+			"Broker should detect credential change after volume mount syncs")
+
+		By("Verifying server becomes unreachable with invalid credentials")
+		Eventually(func() bool {
+			reachable, err := verifyServerInBrokerStatus("http://localhost:18083/status", "mcp-api-key-server", false)
+			if err != nil {
+				// server might be completely removed from status
+				return true
+			}
+			return !reachable // we expect it to be unreachable
+		}, TestTimeoutLong, TestRetryInterval).Should(BeTrue(),
+			"Server should be unreachable or removed with invalid credentials")
+
+		By("Updating credential back to valid value")
+		patch = client.MergeFrom(credentialSecret.DeepCopy())
+		credentialSecret.StringData = map[string]string{
+			"token": "Bearer test-api-key-secret-token",
+		}
+		Expect(k8sClient.Patch(ctx, credentialSecret, patch)).To(Succeed())
+
+		By("Waiting for volume mount to sync valid credential and broker to re-register")
+		// Periodically trigger config reloads until the broker detects the valid credential
+		Eventually(func() bool {
+			// trigger config reload
+			mcpServerPatch := client.MergeFrom(mcpServerApiKey.DeepCopy())
+			if mcpServerApiKey.Annotations == nil {
+				mcpServerApiKey.Annotations = make(map[string]string)
+			}
+			mcpServerApiKey.Annotations["reconcile"] = fmt.Sprintf("%d", time.Now().Unix())
+			if err := k8sClient.Patch(ctx, mcpServerApiKey, mcpServerPatch); err != nil {
+				return false
+			}
+
+			// wait a moment for the config push to process
+			time.Sleep(2 * time.Second)
+
+			// check if server became reachable again
+			reachable, err := verifyServerInBrokerStatus("http://localhost:18083/status", "mcp-api-key-server", true)
+			return err == nil && reachable
+		}, TestTimeoutConfigSync, 10*time.Second).Should(BeTrue(),
+			"Server should be reachable again with valid credentials after volume mount syncs")
+
+		By("Test completed successfully")
+	})
 })
+
+// helper to check if server exists in broker status and its reachability
+func verifyServerInBrokerStatus(statusURL, serverNamePart string, expectReachable bool) (bool, error) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(statusURL)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("status endpoint returned %d", resp.StatusCode)
+	}
+
+	type StatusResponse struct {
+		Servers []struct {
+			URL              string `json:"url"`
+			Name             string `json:"name"`
+			ConnectionStatus struct {
+				IsReachable bool `json:"isReachable"`
+			} `json:"connectionStatus"`
+		} `json:"servers"`
+	}
+
+	var status StatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return false, err
+	}
+
+	for _, server := range status.Servers {
+		if strings.Contains(server.URL, serverNamePart) {
+			return server.ConnectionStatus.IsReachable == expectReachable, nil
+		}
+	}
+
+	// server not found in status
+	return false, fmt.Errorf("server %s not found in status", serverNamePart)
+}
 
 // helper function to setup port-forward
 func setupPortForward(resource, namespace, ports string) *exec.Cmd {


### PR DESCRIPTION
Re: https://github.com/kagenti/mcp-gateway/issues/200

Adds secret watching for faster updates and fixes credential value change detection. Previously, credential changes required broker restarts or weren't detected at all.

## changes

- Credential secrets now require `mcp.kagenti.com/credential="true"` label for the controller to watch them
- Controller watches labeled secrets and reconciles `MCPServer` resources when credentials change
- Broker detects credential value changes (not just env var name changes) and re-registers servers
- Uses the existing HTTP config push API for propagation without pod restarts
- `MCPServer` resources reject unlabelled secrets with clear status messages

## notes on timing

- **Initial server registration**: Takes 10-30 seconds as the broker needs to connect and authenticate
- **Credential updates**: Controller detects immediately, but broker re-registration takes 60-120s due to Kubernetes volume mount sync delays
- **Volume mounts**: Still used (replacing envFrom), so the 60-120s kubelet sync delay remains, but the broker now properly detects changes once synced

## Example

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: github-token
  namespace: mcp-test
  labels:
    mcp.kagenti.com/credential: "true"  # required label
type: Opaque
stringData:
  token: "Bearer ghp_YOUR_TOKEN"
---
apiVersion: mcp.kagenti.com/v1alpha1
kind: MCPServer
metadata:
  name: github
  namespace: mcp-test
spec:
  toolPrefix: github_
  targetRef:
    kind: HTTPRoute
    name: github-route
  credentialRef:
    name: github-token
    key: token
```

## Verifying

Deploy:
```bash
make local-env-setup
```

### Test labeled secret
```bash
kubectl apply -f config/test-servers/api-key-server-secret.yaml

# wait for initial server registration (10-30s)
sleep 30

kubectl get mcpserver api-key-server -n mcp-test -o jsonpath='{.status.conditions[0].message}'
# Expected: MCPServer successfully reconciled and validated 1 servers with 1 tools
```

### Test unlabeled secret (should fail):
```bash
# Create unlabeled secret
kubectl create secret generic bad-secret --from-literal=token=test -n mcp-test

# Create MCPServer referencing it (example):
cat <<EOF | kubectl apply -f -
apiVersion: mcp.kagenti.com/v1alpha1
kind: MCPServer
metadata:
  name: bad-example
  namespace: mcp-test
spec:
  toolPrefix: bad_
  targetRef:
    kind: HTTPRoute
    name: some-route
  credentialRef:
    name: bad-secret
    key: token
EOF

# Check status - should show validation error
kubectl get mcpserver bad-example -n mcp-test -o jsonpath='{.status.conditions[0].message}'
# Expected: credential secret bad-secret is missing required label mcp.kagenti.com/credential=true
```

## Additional Verification

### Monitor controller activity:
```bash
# In a new terminal:
kubectl logs -n mcp-system deployment/mcp-controller -f | grep -E "Reconciling|credential|aggregated"
```

### Test credential updates:
```bash
# Update a labeled secret
kubectl patch secret api-key-server-credentials -n mcp-test \
  -p '{"stringData":{"token":"Bearer updated-token"}}'

# Controller updates aggregated secret immediately (2-5 seconds)
kubectl get secret mcp-aggregated-credentials -n mcp-system -o jsonpath='{.data.KAGENTAI_API_KEY_SERVER_CRED}' | base64 -d
# Should show: Bearer updated-token

# Monitor broker for re-registration (takes 60-120s due to volume mount sync)
kubectl logs -n mcp-system deployment/mcp-broker-router --tail=100 -f | grep -E "Registering server|credential"

# after ~60-120s, broker will detect the change and re-register:
# "Credential changed for existing server, re-registering"
# "Registering server mcpURL=http://mcp-api-key-server..."
```

### Verify broker status:
```bash
# Port-forward to check broker's /status endpoint
kubectl port-forward -n mcp-system deployment/mcp-broker-router 8080:8080 &

# Check registered servers
curl -s http://localhost:8080/status | jq '.servers[] | select(.name | contains("api-key")) | {name, toolPrefix, toolCount: .capabilitiesValidation.toolCount}'
```
