### PR TITLE
fixes: recovery from MCPServer failure/outages, and targetRef changes

### DIFF
--- a/build/ci.mk
+++ b/build/ci.mk
@@ -22,6 +22,8 @@ ci-setup: ## Setup environment for CI (assumes Kind cluster exists)
 	$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-test-server1 -n mcp-test
 	$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-test-server2 -n mcp-test
 	$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-test-server3 -n mcp-test
+	$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-api-key-server -n mcp-test
+	$(KUBECTL) wait --for=condition=available --timeout=180s deployment/mcp-custom-path-server -n mcp-test
 
 # Collect debug info on failure
 .PHONY: ci-debug-logs

--- a/config/mcp-system/deployment-broker.yaml
+++ b/config/mcp-system/deployment-broker.yaml
@@ -40,6 +40,13 @@ spec:
                 secretKeyRef:
                   name: mcp-config-update-token
                   key: token
+            # retry configuration for failed server discovery (optional)
+            # - name: MCP_GATEWAY_DISCOVERY_RETRY_BASE_DELAY
+            #   value: "5s"  # initial retry delay (default: 5s)
+            # - name: MCP_GATEWAY_DISCOVERY_RETRY_MAX_DELAY
+            #   value: "5m"  # maximum retry delay (default: 5m)
+            # - name: MCP_GATEWAY_DISCOVERY_RETRY_MAX_ATTEMPTS
+            #   value: "10"  # maximum retry attempts (default: 10)
           envFrom:
             - secretRef:
                 name: mcp-aggregated-credentials


### PR DESCRIPTION
Re: https://github.com/kagenti/mcp-gateway/issues/209
Re: https://github.com/kagenti/mcp-gateway/issues/210

Implements recovery from MCP server failures and configuration change detection for re-registration

### changes

- Exponential backoff retry when server discovery fails (5s, 10s, 20s... up to 5min). Configurable via env-vars.
- Config change detection compares existing vs new server configuration
- Automatic re-registration when targetRef changes to different HTTPRoute
- extends the happy-path e2e test to cover

### Example

When a server fails:
```bash
# Scale down test server
kubectl scale deploy test-server1 --replicas=0 -n mcp-test

# Broker logs show retry attempts:
# "Starting retry for failed server" url=http://test-server1.mcp-test.svc.cluster.local:8080/mcp attempt=0
# "Retry attempt 1/10 in 5s" url=http://test-server1.mcp-test.svc.cluster.local:8080/mcp
# "Retry attempt 2/10 in 10s" url=http://test-server1.mcp-test.svc.cluster.local:8080/mcp

# Scale back up
kubectl scale deploy test-server1 --replicas=1 -n mcp-test

# Automatic recovery:
# "Retry successful after 3 attempts" url=http://test-server1.mcp-test.svc.cluster.local:8080/mcp
```

When targetRef changes:
```yaml
apiVersion: mcp.kagenti.com/v1alpha1
kind: MCPServer
metadata:
  name: test-server
spec:
  toolPrefix: test_
  targetRef:
    kind: HTTPRoute
    name: route-v1  # Change to route-v2
```

Broker detects and handles the change:
```
# "mcp server config changed, re-registering" mcpURL=... oldPrefix=test_ newPrefix=test_
# "Successfully registered MCP server" mcpURL=http://new-backend:8080/mcp
```

## Verifying

Deploy test environment:
```bash
make local-env-setup
```

Test recovery from failure:
```bash
# scale down test server
kubectl scale deploy test-server1 --replicas=0 -n mcp-test
# retry attempts
kubectl logs -n mcp-system deploy/mcp-broker-router | grep -i retry
# scale back up server
kubectl scale deploy test-server1 --replicas=1 -n mcp-test
# recovery
kubectl logs -n mcp-system deploy/mcp-broker-router | grep "successful after"
```

Test targetRef changes:
```bash
# Change an MCPServer targetRef
kubectl patch mcpserver test-server1 -n mcp-test --type merge \
  -p '{"spec":{"targetRef":{"name":"mcp-server2-route"}}}'
# re-registration
kubectl logs -n mcp-system deploy/mcp-broker-router | grep "config changed"
```
