### PR TITLE
kustomize install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ generate-crds: ## Generate CRD manifests from Go types
 
 # Install CRD
 install-crd: ## Install MCPServer and MCPVirtualServer CRDs
-	kubectl apply -f config/crd/
+	kubectl apply -f config/crd/mcp.kagenti.com_mcpservers.yaml
+	kubectl apply -f config/crd/mcp.kagenti.com_mcpvirtualservers.yaml
 
 # Deploy mcp-gateway components
 deploy: install-crd ## Deploy broker/router and controller to mcp-system namespace

--- a/README.md
+++ b/README.md
@@ -20,7 +20,43 @@ Running in Kubernetes gets you:
 ### Bring Your Own Policies
 The router sets metadata on requests that any Envoy filter can use. We use Kuadrant in our examples for auth and rate limiting, but you can plug in whatever you want - custom ext_authz, WASM modules, or any other Envoy-compatible policy engine.
 
-## Quick Start with mcp-inspector
+## Quick Install
+
+### minimal installation (bring your own infrastructure)
+
+If you already have a Kubernetes cluster with [Gateway API](https://gateway-api.sigs.k8s.io/guides/) installed, install just the MCP Gateway components:
+
+```bash
+# Install Gateway API CRDs
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+# Install MCP Gateway (quotes required for zsh)
+kubectl apply -k 'https://github.com/kagenti/mcp-gateway/config/install?ref=main'
+```
+
+This installs:
+- MCP gateway CRDs
+- Broker/router deployment
+- Controller deployment
+- RBAC resources
+
+see [config/install/README.md](./config/install/README.md) for details and prerequisites.
+
+### Development Environment
+
+For a complete local environment with all dependencies (Istio, Gateway API, Keycloak, MCP test servers):
+
+```bash
+make local-env-setup
+```
+
+this sets up:
+- a `kind` cluster
+- Istio as a Gateway API provider
+- MCP Gateway components (Broker / Router / Controller)
+- Test MCP servers
+- example configurations
+
+## Quick start with mcp-inspector
 
 Set up a local kind cluster with the Broker, Router & Controller running.
 These components are built during the make target into a single image and loaded into the cluster.

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mcp.kagenti.com_mcpservers.yaml
+  - mcp.kagenti.com_mcpvirtualservers.yaml

--- a/config/install/README.md
+++ b/config/install/README.md
@@ -1,0 +1,116 @@
+# minimal MCP Gateway installation
+
+This directory provides a minimal installation of MCP Gateway with just the core components.
+
+## prerequisites
+
+- kubernetes cluster (1.28+)
+- **gateway API CRDs installed** (required!)
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+  ```
+- gateway controller (istio, envoy gateway, etc.)
+- kubectl configured
+
+**note:** the controller will crash-loop until gateway API CRDs are present
+
+## what gets installed
+
+- MCP Gateway CRDs (`MCPServer`)
+- MCP broker/router deployment
+- MCP controller deployment
+- RBAC (service accounts, roles, bindings)
+- services (mcp-broker-router, mcp-config)
+- basic HTTPRoute for the broker
+
+## what you need to provide
+
+- gateway resource (your own gateway instance)
+- authentication/authorization (optional - kuadrant, keycloak, etc.)
+- TLS certificates (optional)
+- MCP server deployments
+
+## installation
+
+### from GitHub (recommended)
+
+```bash
+kubectl apply -k 'https://github.com/kagenti/mcp-gateway/config/install?ref=main'
+```
+
+or a specific version tag:
+
+```bash
+kubectl apply -k 'https://github.com/kagenti/mcp-gateway/config/install?ref=v0.1.0'
+```
+
+**note:** quotes are required in zsh to prevent globbing on the `?` character
+
+### local development
+
+```bash
+git clone https://github.com/kagenti/mcp-gateway
+cd mcp-gateway
+kubectl apply -k config/install
+```
+
+## verify installation
+
+```bash
+# check namespace created
+kubectl get namespace mcp-system
+
+# check deployments
+kubectl get deployments -n mcp-system
+
+# check CRDs
+kubectl get crd mcpservers.mcp.kagenti.com
+```
+
+## next steps
+
+1. create a gateway resource that the HTTPRoute can attach to
+2. deploy your MCP servers
+3. create MCPServer resources to register them
+4. (optional) configure authentication via AuthPolicy
+
+## example gateway
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: mcp-gateway
+  namespace: mcp-system
+spec:
+  gatewayClassName: istio  # or your gateway class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+    allowedRoutes:
+      namespaces:
+        from: All
+```
+
+## example MCPServer
+
+```yaml
+apiVersion: mcp.kagenti.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+  namespace: mcp-test
+spec:
+  toolPrefix: myserver_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: my-mcp-route
+```
+
+## uninstall
+
+```bash
+kubectl delete -k 'https://github.com/kagenti/mcp-gateway/config/install?ref=main'
+```

--- a/config/install/kustomization.yaml
+++ b/config/install/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# minimal MCP gateway installation
+# brings your own: gateway API, istio/envoy gateway, authentication (optional)
+#
+# install with:
+#   kubectl apply -k https://github.com/kagenti/mcp-gateway/config/install?ref=main
+#
+# or locally:
+#   kubectl apply -k config/install
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # CRDs
+  - ../crd
+
+  # core MCP gateway components
+  - ../mcp-system


### PR DESCRIPTION
Adds a kustomize install option, for minimal install

To run, switch apply to use this ref:

`kubectl apply -k 'https://github.com/jasonmadigan/mcp-gateway/config/install?ref=kustomize-install'`