### PR TITLE
Add helm chart files and workflow

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -31,3 +31,11 @@ jobs:
 
       - name: Run lint checks
         run: make lint
+
+      - name: Check CRD synchronization
+        run: |
+          # Install controller-gen if not available
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+          
+          # Check if CRDs are synchronized
+          make check-crd-sync

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,126 @@
+name: Helm Chart Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      chart_version:
+        description: 'Chart version to release (e.g., 0.1.0)'
+        required: true
+        type: string
+      app_version:
+        description: 'App version (defaults to latest if not specified)'
+        required: false
+        type: string
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  CHART_NAME: mcp-gateway
+
+concurrency:
+  group: helm-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate-and-package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: '3.14.0'
+
+    - name: Validate chart version format
+      run: |
+        if [[ ! "${{ inputs.chart_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Error: Chart version must be in format X.Y.Z (e.g., 0.1.0)"
+          exit 1
+        fi
+
+    - name: Update Chart.yaml versions
+      run: |
+        sed -i "s/version: .*/version: ${{ inputs.chart_version }}/" charts/mcp-gateway/Chart.yaml
+        sed -i "s/appVersion: .*/appVersion: \"${{ inputs.app_version }}\"/" charts/mcp-gateway/Chart.yaml
+        
+        echo "Updated Chart.yaml:"
+        cat charts/mcp-gateway/Chart.yaml
+
+    - name: Lint Helm chart
+      run: |
+        helm lint charts/mcp-gateway
+
+    - name: Template Helm chart (dry run)
+      run: |
+        helm template test-release charts/mcp-gateway --debug
+
+    - name: Run Helm unit tests (if kubeconform is available)
+      run: |
+        # Install kubeconform for validation
+        curl -L https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
+        sudo mv kubeconform /usr/local/bin
+        
+        # Validate generated manifests
+        helm template test-release charts/mcp-gateway | kubeconform -strict -summary
+
+    - name: Package Helm chart
+      run: |
+        helm package charts/mcp-gateway --destination ./chart-packages
+        echo "Generated packages:"
+        ls -la ./chart-packages/
+
+    - name: Login to Container Registry
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+    - name: Push chart to OCI registry
+      run: |
+        chart_package=$(ls ./chart-packages/mcp-gateway-*.tgz)
+        echo "Pushing chart package: $chart_package"
+        helm push "$chart_package" oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+
+    - name: Verify chart installation
+      run: |
+        # Install the chart we just pushed to verify it works
+        helm install test-install oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/mcp-gateway --version ${{ inputs.chart_version }} --dry-run --debug
+
+    - name: Generate release summary
+      run: |
+        echo "## Helm Chart Release Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Chart Name:** ${{ env.CHART_NAME }}" >> $GITHUB_STEP_SUMMARY  
+        echo "- **Chart Version:** ${{ inputs.chart_version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **App Version:** ${{ inputs.app_version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Registry:** ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Installation Command" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "helm install mcp-gateway oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/mcp-gateway --version ${{ inputs.chart_version }}" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  create-git-tag:
+    needs: validate-and-package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Create and push git tag
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        
+        tag_name="chart-v${{ inputs.chart_version }}"
+        git tag -a "$tag_name" -m "Helm chart release v${{ inputs.chart_version }}"
+        git push origin "$tag_name"
+        
+        echo "Created git tag: $tag_name"

--- a/.github/workflows/verify-crd-sync.yaml
+++ b/.github/workflows/verify-crd-sync.yaml
@@ -1,0 +1,112 @@
+name: Verify CRD Sync
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pkg/apis/**'
+      - 'config/crd/**'
+      - 'charts/mcp-gateway/crds/**'
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/apis/**'
+      - 'config/crd/**'
+      - 'charts/mcp-gateway/crds/**'
+  workflow_dispatch:
+
+concurrency:
+  group: crd-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-crd-sync:
+    runs-on: ubuntu-latest
+    name: Verify CRDs are synchronized
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+
+    - name: Install controller-gen
+      run: |
+        go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+
+    - name: Generate CRDs
+      run: |
+        make generate-crds
+
+    - name: Check if Helm CRDs exist
+      run: |
+        if [ ! -d "charts/mcp-gateway/crds" ]; then
+          echo "❌ Helm CRDs directory doesn't exist"
+          echo "Run 'make update-helm-crds' to create and sync CRDs"
+          exit 1
+        fi
+
+    - name: Verify CRDs are in sync
+      run: |
+        echo "Checking if CRDs are synchronized between config/crd/ and charts/mcp-gateway/crds/..."
+        
+        # Check if files exist in both locations
+        for crd_file in config/crd/*.yaml; do
+          filename=$(basename "$crd_file")
+          helm_crd="charts/mcp-gateway/crds/$filename"
+          
+          if [ ! -f "$helm_crd" ]; then
+            echo "❌ Missing CRD in Helm chart: $filename"
+            echo "Run 'make update-helm-crds' to sync CRDs"
+            exit 1
+          fi
+        done
+        
+        # Compare content of CRD files
+        if ! diff -r config/crd/ charts/mcp-gateway/crds/ >/dev/null 2>&1; then
+          echo "❌ CRDs are out of sync!"
+          echo ""
+          echo "Differences found:"
+          diff -r config/crd/ charts/mcp-gateway/crds/ || true
+          echo ""
+          echo "To fix this, run:"
+          echo "  make update-helm-crds"
+          echo ""
+          echo "Or if you want to regenerate from Go types:"
+          echo "  make generate-crds-all"
+          exit 1
+        fi
+        
+        echo "✅ All CRDs are synchronized!"
+
+    - name: Verify Helm chart can be templated
+      run: |
+        # Install Helm
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        
+        # Test that the chart templates correctly with current CRDs
+        helm template test charts/mcp-gateway --debug >/dev/null
+        echo "✅ Helm chart templates successfully with current CRDs"
+
+    - name: Generate sync instructions on failure
+      if: failure()
+      run: |
+        echo "## CRD Synchronization Failed" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "The CRDs in \`config/crd/\` and \`charts/mcp-gateway/crds/\` are out of sync." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### To fix this issue:" >> $GITHUB_STEP_SUMMARY
+        echo "1. If you modified Go types, run:" >> $GITHUB_STEP_SUMMARY
+        echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "   make generate-crds-all" >> $GITHUB_STEP_SUMMARY
+        echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "2. If you only need to sync existing CRDs:" >> $GITHUB_STEP_SUMMARY
+        echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "   make update-helm-crds" >> $GITHUB_STEP_SUMMARY
+        echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "3. Commit the updated files and push again" >> $GITHUB_STEP_SUMMARY

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,161 @@
+# MCP Gateway Helm Chart
+
+This directory contains the Helm chart for deploying MCP Gateway to Kubernetes.
+
+> **Note:** This Helm chart is for **production deployments and distribution**. For local development, continue using the existing Kustomize-based workflow (`make local-env-setup`, `make deploy`, etc.).
+
+## Overview
+
+The MCP Gateway Helm chart deploys:
+- **MCP Broker/Router**: Aggregates and routes MCP (Model Context Protocol) requests
+- **MCP Controller**: Manages MCPServer and MCPVirtualServer custom resources
+- **Custom Resource Definitions (CRDs)**: MCPServer and MCPVirtualServer
+- **RBAC**: Service accounts, roles, and bindings for secure operation
+- **EnvoyFilter**: Configures Istio with the MCP Router ext-proc filter (enabled by default)
+
+## Prerequisites
+
+- **Gateway API Provider** (Istio) including Gateway API CRDs
+- **Some MCP Server** At least 1 MCP server you want to route via the Gateway
+
+### Install from Chart
+
+```bash
+helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --version 0.1.0
+```
+
+> **Note**: The chart defaults to the `mcp-system` namespace to match the controller's expectations.
+
+### Install from Local Chart
+
+```bash
+# From the repository root
+helm install mcp-gateway ./charts/mcp-gateway
+```
+
+## Post Install Setup
+
+**After installing the chart**, follow the complete post-installation setup instructions that are displayed by Helm. These instructions include:
+
+- Configuring your Gateway with an MCP listener  
+- Creating an HTTPRoute to route traffic to the broker
+- Connecting your MCP servers using MCPServer resources
+- Accessing the gateway at your configured hostname
+
+## Configuration
+
+The chart uses sensible defaults and requires minimal configuration. The configurable values are:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Image repository | `ghcr.io/kagenti/mcp-gateway` |
+| `image.tag` | Image tag | `latest` |
+| `configMap.create` | Create initial ConfigMap | `true` |
+| `envoyFilter.create` | Create EnvoyFilter for Istio integration | `true` |
+| `envoyFilter.namespace` | Namespace for EnvoyFilter | `istio-system` |
+
+## Usage
+
+### Creating MCP Servers
+
+After installation, create MCPServer resources to connect MCP servers:
+
+```yaml
+apiVersion: mcp.kagenti.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  toolPrefix: "myserver_"
+  targetRef:
+    group: "gateway.networking.k8s.io"
+    kind: "HTTPRoute"
+    name: "my-server-route"
+  # Optional: for servers requiring authentication
+  credentialRef:
+    name: "my-server-credentials"  
+    key: "token"
+```
+
+You'll find example mcp servers in https://github.com/kagenti/mcp-gateway/tree/main/config/test-servers
+along with the corresponding MCPServer resources in https://github.com/kagenti/mcp-gateway/blob/main/config/samples/mcpserver-test-servers.yaml
+
+### Accessing the Gateway
+
+Using your Client or Agent, configure the Gateway as an mcp server.
+Here is an example config:
+
+```json
+{
+  "mcpServers": {
+    "mcp-gateway": {
+      "transport": {
+        "type": "http",
+        "url": "http://mcp.127-0-0-1.sslip.io/mcp"
+      }
+    }
+  }
+}
+```
+
+Alternatively, if using mcp-inspector or another mcp tool to interact directly with the gateway, point it to the hostname in the HTTPRoute e.g. http://mcp.127-0-0-1.sslip.io/mcp
+
+## Upgrading
+
+```bash
+helm upgrade mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --version 0.2.0
+```
+
+## Uninstalling
+
+```bash
+helm uninstall mcp-gateway
+
+# Note: CRDs are not automatically removed
+# Remove them manually if needed:
+kubectl delete crd mcpservers.mcp.kagenti.com
+kubectl delete crd mcpvirtualservers.mcp.kagenti.com
+```
+
+## Development
+
+### CRD Synchronization
+
+The CRDs in this Helm chart (`charts/mcp-gateway/crds/`) are synchronized from the source CRDs in `config/crd/`. When you modify Go types:
+
+```bash
+# Regenerate CRDs from Go types and sync to Helm chart
+make generate-crds-all
+
+# Or just sync existing CRDs to Helm chart
+make update-helm-crds
+
+# Check if CRDs are synchronized
+make check-crd-sync
+```
+
+**Important:** Always run `make generate-crds-all` after modifying Go types in `pkg/apis/` to keep both locations in sync.
+
+### Testing Local Changes
+
+```bash
+# Lint the chart
+helm lint ./charts/mcp-gateway
+
+# Template and validate
+helm template test ./charts/mcp-gateway --debug
+
+# Install locally for testing
+helm install test-mcp-gateway ./charts/mcp-gateway \
+  --dry-run --debug
+```
+
+### Publishing New Versions
+
+The chart is automatically published to GHCR via GitHub Actions. To release a new version:
+
+1. Go to GitHub Actions → "Helm Chart Release"
+2. Click "Run workflow"
+3. Enter the desired chart version (e.g., `0.2.0`)
+4. Optionally specify app version
+5. Run the workflow

--- a/charts/mcp-gateway/.helmignore
+++ b/charts/mcp-gateway/.helmignore
@@ -1,0 +1,31 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*.sh
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OS generated files
+Thumbs.db
+# Helm
+*.tgz
+.helmignore
+# Local development
+*.local

--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: mcp-gateway
+description: A Kubernetes gateway for aggregating and routing Model Context Protocol (MCP) servers
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/kagenti/mcp-gateway
+sources:
+  - https://github.com/kagenti/mcp-gateway
+maintainers:
+  - name: Kagenti Team
+    url: https://github.com/kagenti
+keywords:
+  - mcp
+  - model-context-protocol
+  - gateway
+  - broker
+  - controller
+annotations:
+  category: Infrastructure

--- a/charts/mcp-gateway/crds/mcp.kagenti.com_mcpservers.yaml
+++ b/charts/mcp-gateway/crds/mcp.kagenti.com_mcpservers.yaml
@@ -1,0 +1,220 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: mcpservers.mcp.kagenti.com
+spec:
+  group: mcp.kagenti.com
+  names:
+    kind: MCPServer
+    listKind: MCPServerList
+    plural: mcpservers
+    shortNames:
+    - mcpsrv
+    singular: mcpserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Tool prefix for federation
+      jsonPath: .spec.toolPrefix
+      name: Prefix
+      type: string
+    - description: Target HTTPRoute
+      jsonPath: .spec.targetRef.name
+      name: Target
+      type: string
+    - description: MCP endpoint path
+      jsonPath: .spec.path
+      name: Path
+      type: string
+    - description: Ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: Number of discovered tools
+      jsonPath: .status.discoveredTools
+      name: Tools
+      type: integer
+    - jsonPath: .spec.credentialRef.name
+      name: Credentials
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPServer defines a collection of MCP (Model Context Protocol) servers to be aggregated by the gateway.
+          It enables discovery and federation of tools from multiple backend MCP servers through HTTPRoute references,
+          providing a declarative way to configure which MCP servers should be accessible through the gateway.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              MCPServerSpec defines the desired state of MCPServer.
+              It specifies which HTTPRoutes point to MCP servers and how their tools should be federated.
+            properties:
+              credentialRef:
+                description: |-
+                  CredentialRef references a Secret containing authentication credentials for the MCP server.
+                  The Secret should contain a key with the authentication token or credentials.
+                  The controller will aggregate these credentials and make them available to the broker
+                  via environment variables following the pattern: KAGENTI_{MCP_NAME}_CRED
+                properties:
+                  key:
+                    default: token
+                    description: |-
+                      Key is the key within the Secret that contains the credential value.
+                      If not specified, defaults to "token".
+                    type: string
+                  name:
+                    description: Name is the name of the Secret resource.
+                    type: string
+                required:
+                - name
+                type: object
+              path:
+                default: /mcp
+                description: |-
+                  Path specifies the URL path where the MCP server endpoint is exposed.
+                  If not specified, defaults to "/mcp".
+                  This allows connecting to MCP servers that use custom paths like "/v1/mcp" or "/api/mcp".
+                type: string
+              targetRef:
+                description: |-
+                  TargetRef specifies an HTTPRoute that points to a backend MCP server.
+                  The referenced HTTPRoute should have backend services that implement the MCP protocol.
+                  The controller will discover the backend service from this HTTPRoute and configure
+                  the broker to federate tools from that MCP server.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group of the target resource.
+                    enum:
+                    - gateway.networking.k8s.io
+                    type: string
+                  kind:
+                    default: HTTPRoute
+                    description: Kind is the kind of the target resource.
+                    enum:
+                    - HTTPRoute
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    type: string
+                  namespace:
+                    description: Namespace of the target resource (optional, defaults
+                      to same namespace)
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              toolPrefix:
+                description: |-
+                  ToolPrefix is the prefix to add to all federated tools from referenced servers.
+                  This helps avoid naming conflicts when aggregating tools from multiple sources.
+                  For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_'
+                  ensure they can coexist as 'server1_search' and 'server2_search'.
+                type: string
+                x-kubernetes-validations:
+                - message: toolPrefix is immutable once set
+                  rule: self == oldSelf || oldSelf == ''
+            required:
+            - targetRef
+            type: object
+          status:
+            description: |-
+              MCPServerStatus represents the observed state of the MCPServer resource.
+              It contains conditions that indicate whether the referenced servers have been
+              successfully discovered and are ready for use.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the MCPServer's state.
+                  Common conditions include 'Ready' to indicate if all referenced servers are accessible.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              discoveredTools:
+                description: DiscoveredTools is the number of tools discovered from
+                  this MCPServer
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/mcp-gateway/crds/mcp.kagenti.com_mcpvirtualservers.yaml
+++ b/charts/mcp-gateway/crds/mcp.kagenti.com_mcpvirtualservers.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: mcpvirtualservers.mcp.kagenti.com
+spec:
+  group: mcp.kagenti.com
+  names:
+    kind: MCPVirtualServer
+    listKind: MCPVirtualServerList
+    plural: mcpvirtualservers
+    shortNames:
+    - mcpvs
+    singular: mcpvirtualserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tools.length()
+      name: Tools
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPVirtualServer defines a virtual server that exposes a specific set of tools.
+          It enables tool-level access control and federation by specifying which tools
+          should be accessible through this virtual endpoint.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              MCPVirtualServerSpec defines the desired state of MCPVirtualServer.
+              It specifies which tools should be exposed by this virtual server.
+            properties:
+              description:
+                description: Description provides a human-readable description of
+                  this virtual server's purpose.
+                type: string
+              tools:
+                description: |-
+                  Tools specifies the list of tool names to expose through this virtual server.
+                  These tools must be available from the underlying MCP servers configured in the system.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+            required:
+            - tools
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -1,0 +1,91 @@
+1. Check the status of your deployment:
+  kubectl get pods -n {{ include "mcp-gateway.namespace" . }} -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+{{- if .Values.envoyFilter.create }}
+2. Verify EnvoyFilter is installed:
+  kubectl get envoyfilter mcp-ext-proc -n {{ .Values.envoyFilter.namespace }}
+{{- end }}
+
+3. Configure your Gateway with an MCP listener:
+  Add this listener to your Gateway resource:
+
+  spec:
+    listeners:
+      - name: mcp
+        hostname: 'mcp.127-0-0-1.sslip.io'
+        port: 8080
+        protocol: HTTP
+        allowedRoutes:
+          namespaces:
+            from: All
+
+4. Create an HTTPRoute to route traffic to the MCP broker:
+  kubectl apply -f - <<EOF
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: mcp-route
+    namespace: {{ include "mcp-gateway.namespace" . }}
+  spec:
+    parentRefs:
+      - name: mcp-gateway  # Your Gateway name
+        namespace: gateway-system  # Your Gateway namespace
+    hostnames:
+      - 'mcp.127-0-0-1.sslip.io'  # Match the Gateway listener hostname
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /mcp
+        filters:
+          - type: ResponseHeaderModifier
+            responseHeaderModifier:
+              add:
+                - name: Access-Control-Allow-Origin
+                  value: "*"
+                - name: Access-Control-Allow-Methods
+                  value: "GET, POST, PUT, DELETE, OPTIONS, HEAD"
+                - name: Access-Control-Allow-Headers
+                  value: "Content-Type, Authorization, Accept, Origin, X-Requested-With"
+                - name: Access-Control-Max-Age
+                  value: "3600"
+                - name: Access-Control-Allow-Credentials
+                  value: "true"
+        backendRefs:
+          - name: {{ include "mcp-gateway.fullname" . }}-broker
+            port: 8080
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /.well-known/oauth-protected-resource
+        backendRefs:
+          - name: {{ include "mcp-gateway.fullname" . }}-broker
+            port: 8080
+  EOF
+
+5. Connect MCP servers by creating MCPServer resources:
+  kubectl apply -f - <<EOF
+  apiVersion: mcp.kagenti.com/v1alpha1
+  kind: MCPServer
+  metadata:
+    name: my-mcp-server
+    namespace: {{ include "mcp-gateway.namespace" . }}
+  spec:
+    toolPrefix: "myserver_"
+    targetRef:
+      group: "gateway.networking.k8s.io"
+      kind: "HTTPRoute"
+      name: "my-server-route"
+  EOF
+
+6. Access your MCP Gateway at: http://mcp.127-0-0-1.sslip.io:8080/mcp
+   (Adjust hostname/port based on your Gateway configuration)
+
+7. View logs for troubleshooting:
+  # Broker/Router logs
+  kubectl logs -n {{ include "mcp-gateway.namespace" . }} deployment/{{ include "mcp-gateway.fullname" . }}-broker-router
+  
+  # Controller logs  
+  kubectl logs -n {{ include "mcp-gateway.namespace" . }} deployment/{{ include "mcp-gateway.fullname" . }}-controller
+
+For more information, visit: https://github.com/kagenti/mcp-gateway

--- a/charts/mcp-gateway/templates/_helpers.tpl
+++ b/charts/mcp-gateway/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mcp-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-gateway.labels" -}}
+helm.sh/chart: {{ include "mcp-gateway.chart" . }}
+{{ include "mcp-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the broker service account to use
+*/}}
+{{- define "mcp-gateway.brokerServiceAccountName" -}}
+{{ include "mcp-gateway.fullname" . }}-broker-router
+{{- end }}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "mcp-gateway.controllerServiceAccountName" -}}
+{{ include "mcp-gateway.fullname" . }}-controller
+{{- end }}
+
+{{/*
+Get the namespace
+*/}}
+{{- define "mcp-gateway.namespace" -}}
+mcp-system
+{{- end }}
+
+{{/*
+Docker image name
+*/}}
+{{- define "mcp-gateway.image" -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}

--- a/charts/mcp-gateway/templates/configmap.yaml
+++ b/charts/mcp-gateway/templates/configmap.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.configMap.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-gateway-config
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    app: mcp-gateway
+    mcp.kagenti.com/aggregated: "true"
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{- if .Values.configMap.data }}
+  {{- toYaml .Values.configMap.data | nindent 2 }}
+  {{- else }}
+  # Default empty configuration - controller will populate this with actual MCP servers
+  config.yaml: |
+    # MCP Gateway Configuration
+    # This initial empty config allows the broker to start successfully.
+    # The controller will update this ConfigMap with actual server configurations
+    # when MCPServer resources are created.
+    servers: []
+    virtualServers: []
+  {{- end }}
+{{- end }}

--- a/charts/mcp-gateway/templates/deployment-broker.yaml
+++ b/charts/mcp-gateway/templates/deployment-broker.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-broker-router
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: broker-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mcp-gateway.selectorLabels" . | nindent 6 }}
+      component: broker-router
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-gateway.selectorLabels" . | nindent 8 }}
+        component: broker-router
+    spec:
+      serviceAccountName: {{ include "mcp-gateway.brokerServiceAccountName" . }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: mcp-gateway-config
+            optional: true
+        - name: mcp-credentials
+          secret:
+            secretName: mcp-aggregated-credentials
+            defaultMode: 0400
+            optional: true
+      containers:
+        - name: mcp-broker-router
+          image: {{ include "mcp-gateway.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - ./mcp_gateway
+            - --mcp-gateway-config=/config/config.yaml
+            - --mcp-broker-public-address=0.0.0.0:8080
+            - --mcp-broker-config-address=0.0.0.0:8181
+            - --mcp-router-address=0.0.0.0:50051
+            - --log-level=-4
+          env:
+            - name: CONFIG_UPDATE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-gateway.fullname" . }}-config-update-token
+                  key: token
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: mcp-aggregated-credentials
+                optional: true
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+            - name: mcp-credentials
+              mountPath: /etc/mcp-credentials
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: config
+              containerPort: 8181
+              protocol: TCP
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/charts/mcp-gateway/templates/deployment-controller.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mcp-gateway.selectorLabels" . | nindent 6 }}
+      component: controller
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-gateway.selectorLabels" . | nindent 8 }}
+        component: controller
+    spec:
+      serviceAccountName: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+      containers:
+        - name: mcp-controller
+          image: {{ include "mcp-gateway.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - ./mcp_gateway
+            - --controller
+            - --log-level=0
+          env:
+            - name: CONFIG_UPDATE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-gateway.fullname" . }}-config-update-token
+                  key: token
+            - name: BROKER_CONFIG_URL
+              value: "http://{{ include "mcp-gateway.fullname" . }}-config.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8181/config"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 8082
+              protocol: TCP
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/charts/mcp-gateway/templates/envoyfilter.yaml
+++ b/charts/mcp-gateway/templates/envoyfilter.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.envoyFilter.create }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: mcp-ext-proc
+  namespace: {{ .Values.envoyFilter.namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          portNumber: 8080
+          filterChain:
+            filter:
+              name: 'envoy.filters.network.http_connection_manager'
+              subFilter:
+                name: 'envoy.filters.http.router'
+      patch:
+        operation: INSERT_FIRST
+        value:
+          name: envoy.filters.http.ext_proc
+          typed_config:
+            '@type': 'type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor'
+            failure_mode_allow: false
+            mutation_rules:
+              allow_all_routing: true
+            message_timeout: 10s
+            processing_mode:
+              request_header_mode: 'SEND'
+              response_header_mode: 'SEND'
+              request_body_mode: 'BUFFERED'
+              response_body_mode: 'BUFFERED'
+              request_trailer_mode: 'SKIP'
+              response_trailer_mode: 'SKIP'
+            grpc_service:
+              envoy_grpc:
+                cluster_name: outbound|50051||{{ include "mcp-gateway.fullname" . }}-broker.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local
+{{- end }}

--- a/charts/mcp-gateway/templates/namespace.yaml
+++ b/charts/mcp-gateway/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if ne (include "mcp-gateway.namespace" .) "default" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/mcp-gateway/templates/rbac.yaml
+++ b/charts/mcp-gateway/templates/rbac.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller
+rules:
+  - apiGroups: ["mcp.kagenti.com"]
+    resources: ["mcpservers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["mcp.kagenti.com"]
+    resources: ["mcpservers/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["mcp.kagenti.com"]
+    resources: ["mcpvirtualservers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+    namespace: {{ include "mcp-gateway.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-broker-router
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: broker-router
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["mcp-gateway-config"]
+    verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-broker-router
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: broker-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mcp-gateway.fullname" . }}-broker-router
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-gateway.brokerServiceAccountName" . }}
+    namespace: {{ include "mcp-gateway.namespace" . }}

--- a/charts/mcp-gateway/templates/secret.yaml
+++ b/charts/mcp-gateway/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-config-update-token
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+type: Opaque
+data:
+  token: {{ randAlphaNum 32 | b64enc | quote }}

--- a/charts/mcp-gateway/templates/service.yaml
+++ b/charts/mcp-gateway/templates/service.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-broker
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: broker
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "mcp-gateway.selectorLabels" . | nindent 4 }}
+    component: broker-router
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-config
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: config-api
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "mcp-gateway.selectorLabels" . | nindent 4 }}
+    component: broker-router
+  ports:
+    - name: http
+      port: 8181
+      targetPort: 8181
+      protocol: TCP

--- a/charts/mcp-gateway/templates/serviceaccount.yaml
+++ b/charts/mcp-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-gateway.brokerServiceAccountName" . }}
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: broker-router
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller

--- a/charts/mcp-gateway/templates/tests/test-connection.yaml
+++ b/charts/mcp-gateway/templates/tests/test-connection.yaml
@@ -24,8 +24,4 @@ spec:
         echo "Checking broker health endpoint..."
         curl -f http://{{ include "mcp-gateway.fullname" . }}-broker.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8080/healthz
         
-        # Test config service health
-        echo "Checking config service..."
-        curl -f http://{{ include "mcp-gateway.fullname" . }}-config.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8181/config
-        
         echo "All tests passed!"

--- a/charts/mcp-gateway/templates/tests/test-connection.yaml
+++ b/charts/mcp-gateway/templates/tests/test-connection.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mcp-gateway.fullname" . }}-test-connection"
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  restartPolicy: Never
+  containers:
+  - name: test-connection
+    image: curlimages/curl:8.5.0
+    command: ['sh', '-c']
+    args:
+      - |
+        set -e
+        echo "Testing MCP Gateway broker connection..."
+        
+        # Test broker health endpoint
+        echo "Checking broker health endpoint..."
+        curl -f http://{{ include "mcp-gateway.fullname" . }}-broker.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8080/healthz
+        
+        # Test config service health
+        echo "Checking config service..."
+        curl -f http://{{ include "mcp-gateway.fullname" . }}-config.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8181/config
+        
+        echo "All tests passed!"

--- a/charts/mcp-gateway/templates/tests/test-status.yaml
+++ b/charts/mcp-gateway/templates/tests/test-status.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mcp-gateway.fullname" . }}-test-status"
+  namespace: {{ include "mcp-gateway.namespace" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  restartPolicy: Never
+  containers:
+  - name: test-status
+    image: curlimages/curl:8.5.0
+    command: ['sh', '-c']
+    args:
+      - |
+        set -e
+        echo "Testing MCP Gateway status endpoint..."
+        
+        # Test status endpoint returns valid JSON
+        response=$(curl -s http://{{ include "mcp-gateway.fullname" . }}-broker.{{ include "mcp-gateway.namespace" . }}.svc.cluster.local:8080/status)
+        echo "Status response: $response"
+        
+        # Check if response contains expected fields
+        echo "$response" | grep -q "servers" || (echo "Status response missing 'servers' field" && exit 1)
+        echo "$response" | grep -q "totalServers" || (echo "Status response missing 'totalServers' field" && exit 1)
+        
+        echo "Status endpoint test passed!"

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -1,0 +1,21 @@
+# Default values for mcp-gateway.
+# This is a YAML-formatted file.
+
+# Image configuration
+image:
+  repository: ghcr.io/kagenti/mcp-gateway
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# ConfigMap for MCP gateway configuration
+configMap:
+  # Create a ConfigMap with default empty configuration
+  # The controller will update this with actual MCP server configurations
+  create: true
+
+# EnvoyFilter for Istio integration
+envoyFilter:
+  # Create EnvoyFilter to route requests through MCP Gateway external processor
+  create: true
+  # Namespace where EnvoyFilter should be created (usually istio-system)
+  namespace: istio-system

--- a/charts/sample_local_helm_setup.sh
+++ b/charts/sample_local_helm_setup.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Sample local Helm setup script for MCP Gateway
+# This script can be run from any directory - it automatically resolves paths
+# relative to the repository root.
+
+set -e
+
+# Get the directory of this script and the repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Setting up MCP Gateway using Helm chart..."
+echo "Repository root: $REPO_ROOT"
+
+kind create cluster --config "$REPO_ROOT/config/kind/cluster.yaml"
+
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+helm install istio-base istio/base -n istio-system --create-namespace --wait
+helm install istiod istio/istiod -n istio-system --wait
+
+kubectl apply -k "$REPO_ROOT/config/istio/gateway"
+kubectl apply -k "$REPO_ROOT/config/test-servers"
+
+helm install mcp-gateway "$REPO_ROOT/charts/mcp-gateway"
+kubectl apply -f "$REPO_ROOT/config/samples/mcpserver-test-servers.yaml"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-route
+  namespace: mcp-system
+spec:
+  parentRefs:
+    - name: mcp-gateway
+      namespace: gateway-system
+  hostnames:
+    - 'mcp.127-0-0-1.sslip.io'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Access-Control-Allow-Origin
+                value: "*"
+              - name: Access-Control-Allow-Methods
+                value: "GET, POST, PUT, DELETE, OPTIONS, HEAD"
+              - name: Access-Control-Allow-Headers
+                value: "Content-Type, Authorization, Accept, Origin, X-Requested-With"
+              - name: Access-Control-Max-Age
+                value: "3600"
+              - name: Access-Control-Allow-Credentials
+                value: "true"
+      backendRefs:
+        - name: mcp-gateway-broker
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/oauth-protected-resource
+      backendRefs:
+        - name: mcp-gateway-broker
+          port: 8080
+EOF
+
+echo "Waiting for MCP Gateway pods to be ready..."
+kubectl wait --for=condition=available --timeout=300s deployment/mcp-gateway-broker-router -n mcp-system
+kubectl wait --for=condition=available --timeout=300s deployment/mcp-gateway-controller -n mcp-system
+
+echo "Waiting for Istio gateway pod to be ready..."
+kubectl wait --for=condition=ready --timeout=300s pod -l istio=ingressgateway -n gateway-system
+
+echo "Starting port forwarding..."
+kubectl -n gateway-system port-forward svc/mcp-gateway-istio 8888:8080 8889:8081 &
+PORT_FORWARD_PID=$!
+
+echo "Starting MCP inspector..."
+MCP_AUTO_OPEN_ENABLED=false DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector@latest &
+INSPECTOR_PID=$!
+
+sleep 3
+
+echo "================================================================"
+echo "Setup complete! 🎉"
+echo "================================================================"
+echo "Port forwarding: kubectl port-forward active (PID: $PORT_FORWARD_PID)"
+echo "MCP Inspector: http://localhost:6274"
+echo "Gateway URL: http://mcp.127-0-0-1.sslip.io:8888/mcp"
+echo ""
+echo "Check status:"
+echo "  kubectl get pods -n mcp-system"
+echo "  kubectl get pods -n istio-system"
+echo "  kubectl get httproute -n mcp-system"
+echo ""
+echo "Press Ctrl+C to stop port forwarding and cleanup."
+echo "================================================================"
+
+open "http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp" 2>/dev/null || echo "Open manually: http://localhost:6274/?transport=streamable-http&serverUrl=http://mcp.127-0-0-1.sslip.io:8888/mcp"
+
+# Cleanup function
+cleanup() {
+    echo "Cleaning up..."
+    kill $PORT_FORWARD_PID 2>/dev/null || true
+    kill $INSPECTOR_PID 2>/dev/null || true
+    exit 0
+}
+
+trap cleanup SIGINT SIGTERM
+wait
+


### PR DESCRIPTION
Adds files and github workflow for publishing a helm chart.
The quickest way to try it out locally (installing the chart from local repo) is to run:

```shell
./charts/sample_local_helm_setup.sh
```

This brings up a kind cluster, installs and configures all pre-reqs, then installs via helm chart.
Sample mcp servers are also deployed with a sample Istio Gateway and HTTPRoute (similar to local dev setup),
and port fordwarding to the gateway setup up for mcp inspector.

For users installing from the helm chart in an existing cluster, the steps in the README can be followed, 
with post-install information given in your terminal after the `helm install` cmd is run.
This approach has a lot more periphery steps, as expected, as you need to have a Gateway configured with a host for the mcp gateway, and a HTTPRoute. You also need to bring along and configure any mcp servers you want to register with the gateway.

NOTE: That by default (there's a config option), an EnvoyFilter is installed via helm to configure Istio, so you don't have to configure the ext-proc.

After merge, I'll run through the release of 0.2 to test & verify publish. cc @huang195 