### PR TITLE
Remove MCPServer from initial test servers resources

### DIFF
--- a/config/test-servers/custom-path-server-httproute.yaml
+++ b/config/test-servers/custom-path-server-httproute.yaml
@@ -22,17 +22,4 @@ spec:
       name: mcp-custom-path-server
       namespace: mcp-test
       port: 8080
----
-apiVersion: mcp.kagenti.com/v1alpha1
-kind: MCPServer
-metadata:
-  name: custom-path-server
-  namespace: mcp-test
-spec:
-  # custom path for this server
-  path: /v1/special/mcp
-  toolPrefix: custompath_
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    name: mcp-custom-path-server
+


### PR DESCRIPTION
The MCPServer resource is included in https://github.com/kagenti/mcp-gateway/blob/653f8f397cd5de0490728c02f904bd3c180a99ba/config/samples/mcpserver-test-servers.yaml#L65-L81 already.
No other MCPServers are included in the config/test-servers folder, just the HTTPRoutes, Deployments & Services.

Avoids an error if applying these test servers before you have the MCPServer CRD installed (which I hit while testing helm install flows)