### PR TITLE
Remove kustomization file in helm resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ generate-crds: ## Generate CRD manifests from Go types
 update-helm-crds: generate-crds ## Update Helm chart CRDs (run after generate-crds)
 	@echo "Copying CRDs to Helm chart..."
 	@mkdir -p charts/mcp-gateway/crds
-	cp config/crd/*.yaml charts/mcp-gateway/crds/
+	cp config/crd/mcp.kagenti.com_*.yaml charts/mcp-gateway/crds/
 	@echo "✅ Helm chart CRDs updated"
 
 # Generate CRDs and update Helm chart in one step

--- a/charts/mcp-gateway/crds/kustomization.yaml
+++ b/charts/mcp-gateway/crds/kustomization.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - mcp.kagenti.com_mcpservers.yaml
-  - mcp.kagenti.com_mcpvirtualservers.yaml


### PR DESCRIPTION
Fix for this error during helm install

```
helm install mcp-gateway oci://ghcr.io/kagenti/charts/mcp-gateway --version 0.2.0

Pulled: ghcr.io/kagenti/charts/mcp-gateway:0.2.0
Digest: sha256:06fc925693d25e0ed238de274108d3708fefc112d228d529460b771ca035a834
Error: INSTALLATION FAILED: failed to install CRD crds/kustomization.yaml: resource mapping not found for name: "" namespace: "" from "": no matches for kind "Kustomization" in version "kustomize.config.k8s.io/v1beta1"
ensure CRDs are installed first
```