### PR TITLE
oAuth + API key

### DIFF
--- a/config/mcp-system/authpolicy.yaml
+++ b/config/mcp-system/authpolicy.yaml
@@ -24,6 +24,12 @@ spec:
               - predicate: size(auth.identity.groups) >=0
               - predicate: request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"] # add method header
       response:
+        success:
+          headers:
+            # copy X-MCP-API-Key to authorization after OAuth validation (if present)
+            # this allows OAuth and backend API keys to coexist (issue #201)
+            'authorization':
+              value: "{request.headers['x-mcp-api-key']}"
         unauthorized:
           code: 401
           headers:

--- a/config/mcp-system/tool-call-auth.yaml
+++ b/config/mcp-system/tool-call-auth.yaml
@@ -25,12 +25,18 @@ spec:
             patterns:
               - predicate: auth.identity.groups.exists(g, request.headers['x-mcp-toolname'] in auth.metadata.rbac.access[g])
       response: #duplicated content may be able to solve
+        success:
+          headers:
+            # copy X-MCP-API-Key to authorization after OAuth validation
+            # this allows OAuth and backend API keys to coexist (issue #201)
+            'authorization':
+              value: "{request.headers['x-mcp-api-key']}"
         unauthorized:
           code: 403
           body:
             value: |
               {
-                "error": "Forbidden", 
+                "error": "Forbidden",
                 "message": "MCP Tool Access denied. Insufficient permissions for this tool."
               }
         unauthenticated:

--- a/internal/mcp-router/headers.go
+++ b/internal/mcp-router/headers.go
@@ -10,6 +10,8 @@ const (
 	mcpServerNameHeader = "x-mcp-servername"
 	toolHeader          = "x-mcp-toolname"
 	methodHeader        = "x-mcp-method"
+	//nolint:gosec // not a credential, just a header name
+	mcpAPIKeyHeader     = "x-mcp-api-key" // header for backend API keys to avoid OAuth conflicts
 	sessionHeader       = "mcp-session-id"
 	authorityHeader     = ":authority"
 	authorizationHeader = "authorization"
@@ -49,6 +51,17 @@ func (hb *HeadersBuilder) WithAuth(cred string) *HeadersBuilder {
 		Header: &basepb.HeaderValue{
 			Key:      authorizationHeader,
 			RawValue: []byte(cred),
+		},
+	})
+	return hb
+}
+
+// WithAPIKey will set the x-mcp-api-key header
+func (hb *HeadersBuilder) WithAPIKey(apiKey string) *HeadersBuilder {
+	hb.headers = append(hb.headers, &basepb.HeaderValueOption{
+		Header: &basepb.HeaderValue{
+			Key:      mcpAPIKeyHeader,
+			RawValue: []byte(apiKey),
 		},
 	})
 	return hb


### PR DESCRIPTION
re: https://github.com/kagenti/mcp-gateway/issues/201

credentialsRef secrets - append as x-mcp-api-key header. If used with oAuth + AP, copy credentialRef into Authorization _post_ JWT validation