### PR TITLE
remove over writing auth header with broker credential

### DIFF
--- a/internal/mcp-router/request.go
+++ b/internal/mcp-router/request.go
@@ -135,9 +135,6 @@ func (s *ExtProcServer) HandleMCPRequest(ctx context.Context, mcpReq *MCPRequest
 	}
 
 	headers.WithAuthority(serverInfo.Hostname)
-	if serverInfo.Credential() != "" {
-		headers.WithAuth(serverInfo.Credential())
-	}
 
 	calculatedResponse, err := s.HeaderAndBodyResponse(headers, mcpReq)
 	if err != nil {


### PR DESCRIPTION
We shouldn't set the auth header based on the credential intended for the broker to interact with the backend MCP