### PR TITLE
Add kustomize install steps

### DIFF
--- a/docs/guides/how-to-install-and-configure.md
+++ b/docs/guides/how-to-install-and-configure.md
@@ -49,7 +49,17 @@ This automatically installs:
 - Required CRDs and RBAC
 - EnvoyFilter for Istio integration
 
-### Method 2: Standalone Installation (Advanced)
+### Method 2: Kustomize
+
+Install using Kubernetes manifests:
+
+```bash
+kubectl apply -k 'https://github.com/kagenti/mcp-gateway/config/install?ref=main'
+```
+
+This provides the same components as Helm but with less configuration flexibility.
+
+### Method 3: Standalone Installation (Advanced)
 
 For non-Kubernetes deployments or advanced use cases, see [Standalone Installation Guide](./binary-install.md).
 

--- a/docs/guides/kind-cluster-setup.md
+++ b/docs/guides/kind-cluster-setup.md
@@ -78,9 +78,10 @@ Your Kind cluster is now ready with Gateway API and Istio installed!
 
 ## Next Steps
 
-Now that you have a cluster with the prerequisites:
+Now that you have a cluster with the prerequisites, choose your installation method:
 
-- **[Install MCP Gateway via Helm](./how-to-install-and-configure.md#method-1-helm-recommended)** - Follow the Helm installation method
+- **[Install MCP Gateway via Helm](./how-to-install-and-configure.md#method-1-helm-recommended)** - Recommended approach
+- **[Install MCP Gateway via Kustomize](./how-to-install-and-configure.md#method-2-kustomize)** - Alternative method
 
 After installation, continue with configuration:
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -25,6 +25,23 @@ kubectl cluster-info
 - Check that Gateway API CRDs are installed: `kubectl get crd gateways.gateway.networking.k8s.io`
 - Ensure Istio is installed: `kubectl get pods -n istio-system`
 
+### Kustomize Installation Fails
+
+**Symptom**: `kubectl apply -k` fails with validation errors
+
+```bash
+# Verify Gateway API CRDs exist
+kubectl get crd gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io
+
+# Check for resource conflicts
+kubectl get mcpserver -A
+kubectl get deployment -n mcp-system
+```
+
+**Solutions**:
+- Install Gateway API CRDs first: `kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml`
+- Delete existing resources if upgrading: `kubectl delete -k 'https://github.com/kagenti/mcp-gateway/config/install?ref=main'`
+
 ### Pods Not Starting
 
 **Symptom**: MCP Gateway pods stuck in `Pending`, `CrashLoopBackOff`, or `ImagePullBackOff`


### PR DESCRIPTION
Follow up on https://github.com/kagenti/mcp-gateway/pull/237#issuecomment-3381826054

Adds the kustomize install cmd and some troubleshooting.

Verification should cover the install and follow on guides after the install (as there may be some differences with helm vs kustomize).
A kind cluster, or any kube cluster an be used to install